### PR TITLE
ci: fail-closed server.json guard + registry-only republish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,6 +136,24 @@ jobs:
             exit 1
           fi
 
+      # The MCP Registry record. Static rules (100-char description cap, version
+      # parity with package.json, namespace) plus the registry's own schema
+      # validator, under the same pinned binary the publish job uses. v4.18.0
+      # reached the registry step with a description over the cap and was
+      # rejected 422 AFTER npm had published; this fails the tag first.
+      - name: Guard server.json (MCP Registry record)
+        working-directory: npm-delimit
+        env:
+          MCP_PUBLISHER_VERSION: "1.8.1"
+          MCP_PUBLISHER_SHA256: "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+        run: |
+          set -euo pipefail
+          base="https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}"
+          curl -sSL -o /tmp/mcp-publisher.tar.gz "$base/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
+          bash scripts/check-server-json.sh /tmp/mcp-publisher
+
       - name: Security check
         working-directory: npm-delimit
         run: bash scripts/security-check.sh

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -1,0 +1,81 @@
+name: Publish MCP Registry record
+
+# Registry-only republish. Use when the npm release is already live but the
+# MCP Registry record is stale or was rejected (v4.18.0: npm published, then
+# the registry returned 422 on a description over its 100-char cap, and a
+# manual publish from a workstation returned 403 because a personal login only
+# grants io.github.<user>/* — org records need the repo's OIDC identity).
+#
+# This never touches npm. It publishes ONLY server.json, from the ref given,
+# under the same pinned + checksum-verified publisher publish.yml uses.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref whose server.json to publish (tag or branch)'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write   # registry login via GitHub Actions OIDC
+
+jobs:
+  registry:
+    runs-on: ubuntu-latest
+    name: Publish server.json
+    env:
+      # Bump BOTH values together, and the same pair in publish.yml.
+      MCP_PUBLISHER_VERSION: "1.8.1"
+      MCP_PUBLISHER_SHA256: "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Fetch pinned mcp-publisher
+        run: |
+          set -euo pipefail
+          base="https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}"
+          curl -sSL -o mcp-publisher.tar.gz "$base/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+
+      - name: Guard server.json
+        run: bash scripts/check-server-json.sh ./mcp-publisher
+
+      - name: Assert the npm version in server.json is live
+        # The record must point at a package that exists, or every registry
+        # consumer installs nothing. Registry-only republish means npm already
+        # happened; prove it rather than assume it.
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('./server.json').packages[0].version")
+          npm view "delimit-cli@$V" version
+
+      - name: Publish to MCP Registry
+        run: |
+          set -euo pipefail
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish server.json
+
+      - name: Read back the registry record
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./server.json').name")
+          WANT=$(node -p "require('./server.json').version")
+          for attempt in 1 2 3 4; do
+            GOT=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&version=latest" \
+              | node -p "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));(d.servers||[]).map(s=>(s.server||s).version).join(',')")
+            if [ "$GOT" = "$WANT" ]; then
+              echo "registry record for $NAME reads $GOT"
+              echo "## MCP Registry record updated: \`$NAME\` @ **$GOT**" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "attempt $attempt: registry reads '$GOT', want $WANT; sleeping $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::registry record did not read back as $WANT"
+          exit 1

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -67,8 +67,11 @@ jobs:
           NAME=$(node -p "require('./server.json').name")
           WANT=$(node -p "require('./server.json').version")
           for attempt in 1 2 3 4; do
+            # Parse failures (a 502/503 HTML body mid-propagation) must count as
+            # "not yet", not abort the step under set -e: the parser never throws.
             GOT=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&version=latest" \
-              | node -p "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));(d.servers||[]).map(s=>(s.server||s).version).join(',')")
+              | node -e "let out='';try{const d=JSON.parse(require('fs').readFileSync(0,'utf8'));out=(d.servers||[]).map(s=>(s.server||s).version).join(',')}catch(e){out='<unparseable:'+e.message.slice(0,40)+'>'}process.stdout.write(out)" \
+              || true)
             if [ "$GOT" = "$WANT" ]; then
               echo "registry record for $NAME reads $GOT"
               echo "## MCP Registry record updated: \`$NAME\` @ **$GOT**" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-server-json.sh
+++ b/scripts/check-server-json.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Fail-closed guard for server.json, the MCP Registry record.
+#
+# Runs BEFORE anything publishes (publish.yml validate job) and before a
+# registry-only republish (registry-publish.yml). Every rule below is a
+# rejection the registry has actually returned or a stale-record failure we
+# have actually shipped:
+#   - description > 100 chars -> registry 422 (v4.18.0, 2026-09-02)
+#   - version drift between server.json and package.json -> record points at
+#     an npm version that does not exist (why versions are checked twice)
+#   - registry schema drift -> mcp-publisher validate (optional arg 1 = path
+#     to a pinned mcp-publisher binary; skipped with a notice if absent)
+#
+# Usage: bash scripts/check-server-json.sh [path/to/mcp-publisher]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+PUBLISHER="${1:-}"
+MAX_DESC=100
+
+fail() { echo "::error file=server.json::$*"; exit 1; }
+
+node -e "JSON.parse(require('fs').readFileSync('server.json','utf8'))" 2>/dev/null \
+  || fail "server.json is not valid JSON"
+
+NAME=$(node -p "require('./server.json').name")
+DESC=$(node -p "require('./server.json').description")
+SRV_VERSION=$(node -p "require('./server.json').version")
+SRV_PKG_VERSION=$(node -p "require('./server.json').packages[0].version")
+SRV_PKG_ID=$(node -p "require('./server.json').packages[0].identifier")
+PKG_VERSION=$(node -p "require('./package.json').version")
+PKG_NAME=$(node -p "require('./package.json').name")
+
+# Length in characters, not bytes: the registry counts characters, and the
+# canon line is ASCII, but a future em-dash must not be double-counted.
+DESC_LEN=$(node -p "[...require('./server.json').description].length")
+if [ "$DESC_LEN" -gt "$MAX_DESC" ]; then
+  fail "description is ${DESC_LEN} chars; the MCP Registry caps it at ${MAX_DESC} (returns 422). Shorten it."
+fi
+if [ "$DESC_LEN" -eq 0 ]; then
+  fail "description is empty"
+fi
+
+if [ "$SRV_VERSION" != "$SRV_PKG_VERSION" ]; then
+  fail "server.json version ($SRV_VERSION) != packages[0].version ($SRV_PKG_VERSION)"
+fi
+if [ "$SRV_VERSION" != "$PKG_VERSION" ]; then
+  fail "server.json version ($SRV_VERSION) != package.json version ($PKG_VERSION)"
+fi
+if [ "$SRV_PKG_ID" != "$PKG_NAME" ]; then
+  fail "server.json packages[0].identifier ($SRV_PKG_ID) != package.json name ($PKG_NAME)"
+fi
+case "$NAME" in
+  io.github.delimit-ai/*) ;;
+  *) fail "name ($NAME) is outside the io.github.delimit-ai/ namespace the repo's OIDC identity can publish" ;;
+esac
+
+if [ -n "$PUBLISHER" ] && [ -x "$PUBLISHER" ]; then
+  "$PUBLISHER" validate server.json
+else
+  echo "::notice::mcp-publisher not supplied; schema validation skipped (static checks passed)"
+fi
+
+echo "server.json OK: $NAME@$SRV_VERSION, description ${DESC_LEN}/${MAX_DESC} chars, npm $SRV_PKG_ID@$SRV_PKG_VERSION"


### PR DESCRIPTION
## Why
v4.18.0 published to npm, then the MCP Registry rejected `server.json` with 422 (description over the 100-char cap) **after** npm was already live. A manual republish from a workstation then returned 403: a personal `mcp-publisher login github` grants `io.github.<user>/*` only, so the `io.github.delimit-ai/` record can only be published by the repo's GitHub Actions OIDC identity.

## What
- **`scripts/check-server-json.sh`** (new, fail-closed): description ≤ 100 characters (character count, not bytes), version parity `server.json` ↔ `package.json` ↔ `packages[0]`, identifier parity, `io.github.delimit-ai/` namespace, then `mcp-publisher validate` under the pinned + checksum-verified binary (skipped with a notice if no binary is supplied). Negative-tested locally: 101-char description, version drift, and wrong namespace are each rejected; current `main` passes (72/100 chars).
- **`publish.yml`** validate job: runs the guard before anything publishes, so an over-cap description fails the tag instead of the post-npm registry step.
- **`registry-publish.yml`** (new): `workflow_dispatch`, registry-only, never touches npm. Publishes `server.json` from a chosen ref via OIDC, asserts the referenced npm version is actually live first, and reads the record back from the registry API (fails if the version does not read back).

## Consequence tier
LOW (CI metadata/workflow; no product code, no npm behaviour change). Validation: both workflows parse; guard pass + 3 negative cases run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH1EtUhWFJjfxeAxavipbD

## Review round 1 — disposition
- **Read-back loop aborting on a non-JSON body (set -e): CONFIRMED, fixed** in the second commit. The parser now never throws; an HTML 502 body yields `<unparseable:...>` and the loop retries. Tested locally with an HTML body.
- **"Path mismatch" in `publish.yml`: NOT a defect — checkout layout fact.** Both jobs check the repo out with `actions/checkout` `path: npm-delimit` (lines 30 and 190 of the existing file), so `working-directory: npm-delimit` IS the repository root. The new step invokes `bash scripts/check-server-json.sh` exactly as the existing `Security check` step invokes `bash scripts/security-check.sh` from the same working directory. `scripts/` and `server.json` are at the repository root.
- **"Path mismatch" in `registry-publish.yml`: NOT a defect.** That workflow checks out at the default root (no `path:`), so `./server.json` and `scripts/check-server-json.sh` resolve at the repo root. The guard script additionally does `cd "$(dirname "$0")/.."`, so it is caller-cwd independent.
