### PR TITLE
docs(readme): bring the What's New version block up to v4.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ delimit deliberate "Should we build rate limiting in-house or use a managed serv
 
 ### v4.18
 
-- **MCP Registry record published on every release** -- the official registry entry now tracks the npm version automatically (it had sat at 4.1.38 since April). Publisher pinned and checksum-verified; a fail-closed `server.json` guard rejects an over-cap description or version drift before the tag publishes.
+- **MCP Registry record published on every release** -- the official registry entry now tracks the npm version automatically. Publisher pinned and checksum-verified; the tag gate asserts both `server.json` version fields, so the record can never point at an npm version that does not exist.
 - **Tool descriptions** -- 16 previously undocumented parameters documented from their signatures; 26 Pro-gated tools state the prerequisite and the exact unlicensed return shape.
 - **Release guards** -- bundle-classification guard no longer flakes on SIGPIPE.
 

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ delimit deliberate "Should we build rate limiting in-house or use a managed serv
 
 ### v4.18
 
-- **MCP Registry record published on every release** -- the official registry entry now tracks the npm version automatically. Publisher pinned and checksum-verified; the tag gate asserts both `server.json` version fields, so the record can never point at an npm version that does not exist.
-- **Tool descriptions** -- 16 previously undocumented parameters documented from their signatures; 26 Pro-gated tools state the prerequisite and the exact unlicensed return shape.
+- **MCP Registry record published on every release** -- the official registry entry now tracks the npm version automatically. Publisher pinned and checksum-verified; the tag gate asserts that both `server.json` version fields match the package version.
+- **Tool descriptions** -- 16 previously undocumented parameters documented from their signatures; 26 Pro-gated tools state the prerequisite and the unlicensed-call response.
 - **Release guards** -- bundle-classification guard no longer flakes on SIGPIPE.
 
 ### v4.17
@@ -284,6 +284,7 @@ delimit deliberate "Should we build rate limiting in-house or use a managed serv
 
 ### v4.16
 
+- **Fail-closed bundle allowlist** -- the npm package ships only explicitly reviewed gateway files; two CI guards block any unclassified or non-allowlisted file from entering the tarball.
 - **Session-end auto-capture** installs in the settings shape Claude Code expects, so end-of-session handoff fires instead of being silently dropped.
 - **Always-on commit-author audit** workflow catches identity drift on the repo.
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,22 @@ delimit deliberate "Should we build rate limiting in-house or use a managed serv
 
 3 free deliberations, then BYOK for unlimited. Works with Grok, Gemini, Claude, GPT-4o.
 
+### v4.18
+
+- **MCP Registry record published on every release** -- the official registry entry now tracks the npm version automatically (it had sat at 4.1.38 since April). Publisher pinned and checksum-verified; a fail-closed `server.json` guard rejects an over-cap description or version drift before the tag publishes.
+- **Tool descriptions** -- 16 previously undocumented parameters documented from their signatures; 26 Pro-gated tools state the prerequisite and the exact unlicensed return shape.
+- **Release guards** -- bundle-classification guard no longer flakes on SIGPIPE.
+
+### v4.17
+
+- **Cross-model continuity on fresh installs** -- `delimit_soul_capture` / `delimit_revive` work without any internal modules via the public `session_continuity` module; captured souls carry deterministic provenance (venture, transcript identity, capture key) for reliable resume across model switches. Existing soul files load unchanged.
+- **Security audit** -- fewer false positives on test fixtures and documentation dummies; suppressed findings are reported, never silently dropped.
+
+### v4.16
+
+- **Session-end auto-capture** installs in the settings shape Claude Code expects, so end-of-session handoff fires instead of being silently dropped.
+- **Always-on commit-author audit** workflow catches identity drift on the repo.
+
 ### v4.1
 
 - **TUI** -- terminal-native Ventures panel, real `delimit think` and `delimit build` commands


### PR DESCRIPTION
## Why
The README's version-labelled release notes under **What's New** stopped at v4.1. Registry listings excerpt that block, so Glama's "What's New" showed v4.1 as current while npm and the MCP Registry are at 4.18.0.

## What
- Adds **v4.18**, **v4.17**, **v4.16** entries, each derived from the matching `CHANGELOG.md` section (registry publish + server.json guard; cross-model continuity on fresh installs; session-end auto-capture + commit-author audit).
- v4.1 / v4.0 entries kept as history. No other README section touched.
- Public-truth check: every command the feature copy names (`wrap`, `trust-page`, `ai-sbom`, `doctor`, `simulate`, `report`, `status`) answered `--help` on the installed delimit-cli 4.18.0.

## Review round 1 — disposition
Unanimous BLOCK (4 seats / 3 vendors): the v4.18 bullet claimed the description-cap `server.json` guard, which merged AFTER the v4.18.0 tag (#192) and is not in the 4.18.0 changelog; the "since April" aside was unsourced. CONFIRMED, fixed in the second commit: the bullet now states only the tag gate's version-field assertion (in the 4.18.0 changelog under CI/CD). The guard will get its own changelog line at the next release.

## Review round 2 — disposition
Unanimous BLOCK (4 seats / 3 vendors): "so the record can never point at an npm version that does not exist" is an ordering guarantee the changelog does not document. CONFIRMED, removed in the third commit; the bullet now states only the tag gate's version-field assertion. Non-blocking notes taken: "unlicensed-call response" (changelog wording); v4.16 now leads with the 4.16.0 fail-closed bundle allowlist.

## Consequence tier
LOW (docs only). Ships with the next npm release; this PR publishes nothing.

Head: ecb134671d7486821f5c60e06c79197db4d11de6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH1EtUhWFJjfxeAxavipbD
