### PR TITLE
fix(cli): `delimit deliberate` runs the installed engine instead of printing instructions (LED-4391 #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ delimit_impact       → blast radius: scans your dependency manifest for downst
 
 ```bash
 npx delimit-cli deliberate "Is dropping the deprecated v1 /users field a safe MINOR?"
-#   tool: delimit_deliberate — 3 free, then bring your own key
+#   tool: delimit_deliberate — 3 hosted runs after `delimit signin` (free account), then bring your own keys
 ```
 
 **Capture the signed, replayable attestation.** After a gate event (deploy / security / test / audit), record the evidence bundle and verify it any time.

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -6104,6 +6104,118 @@ program
     });
 
 // Deliberate command -- entry point for cross-model deliberation
+// ── `delimit deliberate`: resolve and drive the installed engine (LED-4391 #1) ──
+//
+// `delimit setup` installs the deliberation engine into ~/.delimit/server/ai
+// as a compiled module (deliberation.cpython-<py>-<platform>.so, from the
+// core-engine tarball) — never as deliberation.py source. The engine decides
+// hosted-vs-BYOK and the free-tier sign-in requirement itself; the CLI's job
+// is to find it, run it with the venv python that setup created, and render
+// what it says.
+function resolveDeliberationEngine() {
+    const serverDir = homeSubpath('server');
+    const aiDir = path.join(serverDir, 'ai');
+    let entries = [];
+    try {
+        entries = fs.readdirSync(aiDir);
+    } catch {
+        return null;
+    }
+    const hasEngine = entries.some((f) =>
+        f === 'deliberation.py' || /^deliberation\.cpython-[^/]+\.(so|pyd)$/.test(f) || /^deliberation\.[^/]+\.(so|pyd)$/.test(f)
+    );
+    if (!hasEngine) return null;
+    const venvPython = homeSubpath('venv', 'bin', 'python');
+    return {
+        serverDir,
+        python: fs.existsSync(venvPython) ? venvPython : 'python3',
+    };
+}
+
+function runEngineDeliberation(engine, question, { mode = 'dialogue', maxRounds = 2 } = {}) {
+    const { spawnSync } = require('child_process');
+    const deliberationsDir = homeSubpath('deliberations');
+    try { fs.mkdirSync(deliberationsDir, { recursive: true }); } catch { /* engine will fall back */ }
+    const savePath = path.join(deliberationsDir, `cli-${new Date().toISOString().replace(/[:.]/g, '-')}.md`);
+    // The question and options travel via the environment — no shell quoting
+    // of user text, no injection surface.
+    const script = [
+        'import json, os, sys',
+        'sys.path.insert(0, os.environ["DELIMIT_ENGINE_DIR"])',
+        'os.chdir(os.environ["DELIMIT_ENGINE_DIR"])',
+        'from ai.deliberation import deliberate',
+        'q = os.environ["DELIMIT_Q"]',
+        'mode = os.environ["DELIMIT_MODE"]',
+        'rounds = int(os.environ["DELIMIT_ROUNDS"])',
+        'save = os.environ["DELIMIT_SAVE"]',
+        'try:',
+        '    result = deliberate(question=q, mode=mode, max_rounds=rounds, save_path=save)',
+        'except TypeError:',
+        '    result = deliberate(question=q, mode=mode, max_rounds=rounds)',
+        'sys.stdout.write("__DELIMIT_JSON__" + json.dumps(result, default=str))',
+    ].join('\n');
+    const proc = spawnSync(engine.python, ['-c', script], {
+        encoding: 'utf-8',
+        timeout: 30 * 60 * 1000,
+        maxBuffer: 64 * 1024 * 1024,
+        env: {
+            ...process.env,
+            PYTHONPATH: engine.serverDir,
+            DELIMIT_ENGINE_DIR: engine.serverDir,
+            DELIMIT_Q: question,
+            DELIMIT_MODE: mode,
+            DELIMIT_ROUNDS: String(maxRounds),
+            DELIMIT_SAVE: savePath,
+        },
+    });
+    const stdout = proc.stdout || '';
+    const marker = stdout.lastIndexOf('__DELIMIT_JSON__');
+    if (proc.status !== 0 || marker < 0) {
+        const tail = ((proc.stderr || '') + '\n' + stdout).trim().split('\n').slice(-6).join('\n');
+        return { ran: false, error: tail || `engine exited with status ${proc.status}` };
+    }
+    try {
+        return { ran: true, result: JSON.parse(stdout.slice(marker + '__DELIMIT_JSON__'.length)), savePath };
+    } catch (e) {
+        return { ran: false, error: `engine returned unparseable output: ${e.message}` };
+    }
+}
+
+function renderDeliberationOutcome(outcome, question) {
+    if (!outcome.ran) {
+        console.log(chalk.yellow('The deliberation engine did not run:'));
+        console.log(chalk.dim(outcome.error));
+        console.log(`\nInside your AI assistant you can still run ${chalk.cyan(`delimit_deliberate: ${question}`)}`);
+        return;
+    }
+    const r = outcome.result || {};
+    if (r.error) {
+        outcome.ran = false; // engine refused — the question was not deliberated
+        if (r.oauth_required || r.reason === 'oauth_required') {
+            console.log(chalk.yellow('Hosted deliberations need a free delimit.ai account (3 runs per install).'));
+            console.log(`Run ${chalk.cyan('delimit signin')}, then re-run this command.`);
+            if (r.signin_url) console.log(chalk.dim(`Sign-in: ${r.signin_url}`));
+            console.log(chalk.dim('Or bring your own model keys: delimit models'));
+        } else if (r.status === 'premium_required' || /Delimit Pro/.test(String(r.error))) {
+            console.log(chalk.yellow(String(r.error)));
+            if (r.upgrade) console.log(chalk.dim(`Upgrade: ${r.upgrade}`));
+        } else {
+            console.log(chalk.red(`Error: ${r.error}`));
+            if (r.reason) console.log(chalk.dim(`Reason: ${r.reason}`));
+        }
+        return;
+    }
+    const verdict = r.final_verdict || (r.unanimous ? 'UNANIMOUS AGREEMENT' : 'NO CONSENSUS');
+    const rounds = Array.isArray(r.rounds) ? r.rounds.length : (r.rounds || 0);
+    const models = Array.isArray(r.models_used) ? r.models_used : [];
+    console.log(chalk.bold(`Verdict: ${verdict}`));
+    console.log(`Rounds: ${rounds}${r.agreed_at_round ? ` (agreed at round ${r.agreed_at_round})` : ''}`);
+    if (models.length) console.log(`${models.length} models: ${models.join(', ')}`);
+    if (r.summary) { console.log(''); console.log(r.summary); }
+    const transcript = r.save_path || r.transcript_path || outcome.savePath;
+    if (transcript && fs.existsSync(transcript)) console.log(chalk.dim(`\nTranscript: ${transcript}`));
+}
+
 program
     .command('deliberate [question...]')
     .description('Deliberate on a strategic question using cross-model consensus')
@@ -6150,49 +6262,30 @@ program
             console.log(chalk.blue.bold('\nDelimit Deliberation\n'));
             console.log(`Question: ${chalk.bold(question)}\n`);
 
-            // Try to run deliberation directly via the gateway
-            const gatewayScript = homeSubpath('server', 'ai', 'deliberation.py');
-            const scriptPath = fs.existsSync(gatewayScript) ? gatewayScript : null;
+            // Run the engine that `delimit setup` installed. Every install
+            // gets the deliberation engine as a compiled module
+            // (deliberation.cpython-*.so, downloaded with the core engine
+            // tarball); the previous code looked for the engine's Python
+            // SOURCE file and a function that the engine does not export,
+            // neither of which exists on any customer machine, so this
+            // command had only ever printed instructions (LED-4391 #1).
+            const engine = resolveDeliberationEngine();
 
-            if (scriptPath) {
-                console.log(chalk.dim('Running multi-model deliberation...\n'));
-                try {
-                    const escapedQ = question.replace(/'/g, "\\'");
-                    const pyCmd = `python3 -c "
-import sys, os, json
-sys.path.insert(0, os.path.dirname('${scriptPath}'))
-os.chdir(os.path.dirname('${scriptPath}'))
-from deliberation import run_deliberation
-result = run_deliberation('${escapedQ}', mode='${options.mode}', max_rounds=2)
-if result.get('verdict'):
-    print('VERDICT:', result['verdict'])
-if result.get('confidence'):
-    print('CONFIDENCE:', result['confidence'])
-if result.get('summary'):
-    print()
-    print(result['summary'])
-"`;
-                    const result = execSync(pyCmd, {
-                        encoding: 'utf-8',
-                        timeout: 120000,
-                        env: { ...process.env, PYTHONPATH: path.dirname(scriptPath) },
-                    });
-                    console.log(result);
-                } catch (e) {
-                    // Fallback: guide user to MCP tool
-                    console.log(chalk.yellow('Direct deliberation unavailable. Use the MCP tool instead:\n'));
-                    console.log(chalk.bold('In your AI assistant (Claude Code, Codex, or Gemini CLI):'));
-                    console.log(`   ${chalk.cyan(`delimit_deliberate: ${question}`)}\n`);
+            if (engine) {
+                console.log(chalk.dim(`Running multi-model deliberation (${options.mode})...\n`));
+                const outcome = runEngineDeliberation(engine, question, { mode: options.mode, maxRounds: 2 });
+                renderDeliberationOutcome(outcome, question);
+                if (outcome.ran) {
+                    return;
                 }
             } else {
-                console.log('To deliberate, use one of the following approaches:\n');
-                console.log(chalk.bold('1. In your AI assistant (Claude Code, Codex, or Gemini CLI):'));
+                console.log(chalk.yellow('Deliberation engine not installed yet.'));
+                console.log(`Run ${chalk.cyan('delimit setup')} first (it installs the engine), then re-run this command.\n`);
+                console.log(chalk.bold('Or, inside your AI assistant (Claude Code, Codex, or Gemini CLI):'));
                 console.log(`   ${chalk.cyan(`delimit_deliberate: ${question}`)}\n`);
-                console.log(chalk.bold('2. Using the MCP tool directly:'));
-                console.log(`   ${chalk.cyan(`Call delimit_deliberate with question="${question}"`)}\n`);
             }
 
-            // Save pending deliberation to file for reference
+            // Not run: park the question so the next session can pick it up.
             const deliberationDir = homeSubpath('deliberation');
             fs.mkdirSync(deliberationDir, { recursive: true });
             const pending = {

--- a/tests/cli-deliberate-runs-engine.test.js
+++ b/tests/cli-deliberate-runs-engine.test.js
@@ -1,0 +1,87 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+/**
+ * LED-4391 finding 1: `delimit deliberate` never deliberated. It looked for
+ * a `deliberation.py` SOURCE file (customers only ever get the compiled
+ * `deliberation.cpython-*.so` from the core-engine tarball) and imported a
+ * `run_deliberation` function that does not exist, so every customer run
+ * fell through to "use the MCP tool" + pending.json.
+ *
+ * These tests pin the new contract: the command resolves the installed
+ * engine as a MODULE, invokes `ai.deliberation.deliberate`, surfaces the
+ * hosted-tier sign-in requirement, and only parks the question when it
+ * genuinely could not run.
+ */
+
+const CLI = fs.readFileSync(path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'utf-8');
+
+describe('delimit deliberate: engine resolution and invocation (LED-4391 #1)', () => {
+    it('no longer depends on a deliberation.py source file or run_deliberation', () => {
+        const start = CLI.indexOf(".command('deliberate [question...]')");
+        assert.ok(start > 0, 'deliberate command not found');
+        const handler = CLI.slice(start, CLI.indexOf(".command('", start + 10));
+        assert.doesNotMatch(handler, /deliberation\.py/, 'must not look for the proprietary SOURCE file');
+        assert.doesNotMatch(handler, /run_deliberation/, 'that function does not exist in the engine');
+        assert.match(handler, /resolveDeliberationEngine\(\)/);
+        assert.match(handler, /runEngineDeliberation\(/);
+    });
+
+    it('invokes ai.deliberation.deliberate with the question, mode and max_rounds, emitting JSON', () => {
+        const start = CLI.indexOf('function runEngineDeliberation(');
+        assert.ok(start > 0, 'runEngineDeliberation helper missing');
+        const body = CLI.slice(start, start + 4000);
+        assert.match(body, /from ai\.deliberation import deliberate/);
+        assert.match(body, /deliberate\(\s*question=/);
+        assert.match(body, /mode=/);
+        assert.match(body, /max_rounds=/);
+        assert.match(body, /json\.dumps/);
+    });
+
+    it('resolves the engine from the installed compiled module OR a source file, using the setup venv python when present', () => {
+        const start = CLI.indexOf('function resolveDeliberationEngine(');
+        assert.ok(start > 0, 'resolveDeliberationEngine helper missing');
+        const body = CLI.slice(start, start + 2500);
+        assert.match(body, /deliberation\\?\.cpython-/, 'compiled engine module must be recognised');
+        assert.match(body, /venv/, 'must prefer the venv python that `delimit setup` created');
+    });
+
+    it('renders the hosted sign-in requirement instead of a generic failure', () => {
+        const start = CLI.indexOf('function renderDeliberationOutcome(');
+        assert.ok(start > 0, 'renderDeliberationOutcome helper missing');
+        const body = CLI.slice(start, start + 3000);
+        assert.match(body, /oauth_required/);
+        assert.match(body, /delimit signin/);
+        assert.match(body, /final_verdict/);
+    });
+
+    it('end-to-end against a stub engine: runs, parses JSON, and reports the verdict', () => {
+        // Build a fake ~/.delimit with a python "engine" whose deliberate()
+        // returns a canned transcript, then drive the real CLI against it.
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-delib-'));
+        const serverAi = path.join(home, '.delimit', 'server', 'ai');
+        fs.mkdirSync(serverAi, { recursive: true });
+        fs.writeFileSync(path.join(serverAi, '__init__.py'), '');
+        fs.writeFileSync(path.join(serverAi, 'deliberation.py'), [
+            'def deliberate(question, context="", max_rounds=3, mode="dialogue", **kw):',
+            '    return {"final_verdict": "UNANIMOUS AGREEMENT", "unanimous": True, "rounds": [1, 2],',
+            '            "agreed_at_round": 2, "models_used": ["a", "b", "c"], "question": question, "mode": mode}',
+        ].join('\n'));
+        const r = spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'deliberate', 'Is', 'this', 'wired?'], {
+            env: { ...process.env, HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
+            encoding: 'utf-8', timeout: 60000,
+        });
+        try {
+            assert.strictEqual(r.status, 0, r.stderr);
+            assert.match(r.stdout, /UNANIMOUS AGREEMENT/);
+            assert.match(r.stdout, /3 models/);
+            assert.doesNotMatch(r.stdout, /pending\.json/, 'a deliberation that ran must not be parked as pending');
+        } finally {
+            fs.rmSync(home, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Why (LED-4391 finding 1, fresh-user install test 2026-09-02)
On every customer machine `delimit deliberate` printed "use the MCP tool" and wrote `pending.json` — it never deliberated. Two dead assumptions: it looked for a `deliberation.py` **source** file (`delimit setup` installs the engine as a compiled `deliberation.cpython-*.so` from the core-engine tarball, v3.10.0), and it imported `run_deliberation`, which the engine does not export. Meanwhile the README Golden Path advertised the command with "3 free, then bring your own key".

## What
- **Engine resolution**: `resolveDeliberationEngine()` accepts the compiled module or a source file under `~/.delimit/server/ai`, and prefers the venv python that setup created.
- **Invocation**: `runEngineDeliberation()` calls `ai.deliberation.deliberate(question=…, mode=…, max_rounds=2, save_path=…)`; the question travels via the environment (no shell quoting, no injection surface); the result comes back as JSON behind a marker.
- **Rendering**: verdict, rounds, models, transcript path. The engine's hosted-tier sign-in requirement (LED-2092) renders as "run `delimit signin`" with the sign-in URL; a Pro gate renders as such. `pending.json` is written only when the deliberation genuinely did not run.
- **README**: Golden Path line now says "3 hosted runs after `delimit signin` (free account), then bring your own keys" — what the engine and the license quota (`delimit_deliberate: 3`) actually enforce.
- Not touched: `delimit think` (same class of issue, separate follow-up).

## Verification
- `tests/cli-deliberate-runs-engine.test.js` (5): structural pins on the new contract + an end-to-end run of the real CLI against a stub engine in a temp HOME (asserts the verdict is printed and nothing is parked as pending).
- Real engine on a developer box: `delimit deliberate --mode dialogue "…"` → UNANIMOUS AGREEMENT, 4 models, 50 s, transcript written.
- Not yet verified: a free-tier machine's sign-in path end-to-end (needs a fresh install + the hosted quota); the rendering branch is unit-covered only.

Consequence tier: MEDIUM (customer CLI behaviour; no MCP surface change). Prepared for founder review — not merged.

Head: c269ee29e84eadb7fbeb1f872d8ce66a55e3616d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jjhrqspGpTJAeN3WLPZzC
