### PR TITLE
sync(gateway): server.py from f85b99f — parent-death monitor no longer exits when the client is PID 1 (Glama)

### DIFF
--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -15141,16 +15141,31 @@ def delimit_handoff_list(
 #  ENTRY POINT
 # ═══════════════════════════════════════════════════════════════════════
 
+def _parent_gone(original_ppid: int, current_ppid: int) -> bool:
+    """True when the client that spawned this server has died.
+
+    The only reliable signal is a CHANGE of parent: on Linux an orphan is
+    re-parented (to PID 1 or a subreaper), so ``current != original`` is
+    the whole test. The previous predicate also treated ``current == 1``
+    as death, which killed the server ~1 s after start whenever the
+    spawning client legitimately IS PID 1 — every container runtime that
+    execs the MCP client as the entrypoint (Glama's ``mcp-proxy`` image,
+    ``docker run … mcp-proxy -- python server.py``). Glama's build tests
+    failed on every release from 2026-06-25 to 4.18.1 for this reason.
+    """
+    return current_ppid != original_ppid
+
+
 async def run_mcp_server(server, server_name="delimit"):
     """Run the MCP server."""
-    
+
     # Fix for Issue #142 (Credit: Ryofukutani): Prevent zombie process on client disconnect
     if os.name == 'posix':
         import time
         def _monitor_parent():
             original_ppid = os.getppid()
             while True:
-                if os.getppid() != original_ppid or os.getppid() == 1:
+                if _parent_gone(original_ppid, os.getppid()):
                     os._exit(0)
                 time.sleep(1)
         threading.Thread(target=_monitor_parent, daemon=True, name="parent_monitor").start()


### PR DESCRIPTION
## Why
Glama builds this server from **this repo's main** (`gateway/ai/server.py`) and runs it as `mcp-proxy -- python gateway/ai/server.py` with mcp-proxy as the container's PID 1. Every Glama build test from 2026-06-25 to 4.18.1 failed with "Container exited with code 1 before responding to ping": the Issue #142 zombie fix exits the server when `os.getppid() == 1`, which is that runtime's normal parent. Their release tracking froze at 4.13.1 for the same reason. Fixed in gateway as delimit-ai/delimit-gateway#415 (unanimous 4/3, merged f85b99f); this PR carries it into the bundle so Glama can rebuild before the next npm release.

## What
Sync-only. `gateway/ai/server.py` +17/−2 from gateway `f85b99f`: `_parent_gone(original_ppid, current_ppid)` returns `current != original` (orphan re-parenting is the only reliable death signal); the monitor thread uses it. No other bundle file changed (classification guard green; `sync-gateway` against a clean export of f85b99f produced exactly this delta).

## Verification
- From this exact tree, under Glama's build spec (debian slim, uv venv, python 3.11, mcp-proxy 6.4.3): the server **stays up with mcp-proxy as PID 1**; the unpatched image dies in under a second with Glama's exact error.
- Gateway tests for the predicate: 7/7 (`tests/test_parent_monitor_pid1.py`, gateway-side).

## After merge
Founder re-runs the Glama Dockerfile test from the listing's Admin tab; expected: status success, then "Recent Releases" advancing past 4.13.1 and the README "What's New" v4.18 block appearing on the listing. LED-4393.

Consequence tier: MEDIUM (customer MCP server startup; content already reviewed in gateway#415).

Head: 20813e8c622c1c6ed8ece2148d06da4fc79b7074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jjhrqspGpTJAeN3WLPZzC
