### PR TITLE
fix(funnel): truthful shim banner, pinned Docker fastmcp fallback, encoded registry read-back URL (LED-4391 #6/#7)

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -74,10 +74,12 @@ jobs:
           set -euo pipefail
           NAME=$(node -p "require('./server.json').name")
           WANT=$(node -p "require('./server.json').version")
+          # The name contains a slash (io.github.<org>/<repo>); encode it for the query string.
+          NAME_ENC=$(NAME="$NAME" node -p "encodeURIComponent(process.env.NAME)")
           for attempt in 1 2 3 4; do
             # Parse failures (a 502/503 HTML body mid-propagation) must count as
             # "not yet", not abort the step under set -e: the parser never throws.
-            GOT=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&version=latest" \
+            GOT=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME_ENC}&version=latest" \
               | NAME="$NAME" node -e "let out='';try{const d=JSON.parse(require('fs').readFileSync(0,'utf8'));const hit=(d.servers||[]).map(s=>s.server||s).find(s=>s.name===process.env.NAME);out=hit?String(hit.version):'<no exact-name match>'}catch(e){out='<unparseable:'+e.message.slice(0,40)+'>'}process.stdout.write(out)" \
               || true)
             if [ "$GOT" = "$WANT" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ WORKDIR /app
 
 # Install Python dependencies
 COPY gateway/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt 2>/dev/null || pip install pyyaml pydantic packaging fastmcp
+# The fallback MUST pin the same fastmcp as gateway/requirements.txt and the
+# delimit-setup.js no-reqfile fallback, so a `delimit setup` venv and this
+# image run the same fastmcp (fresh-user install test 2026-09-02, finding 7:
+# the unpinned fallback landed on 4.0.2 while setup venvs ran 3.1.0).
+RUN pip install --no-cache-dir -r requirements.txt 2>/dev/null \
+    || pip install --no-cache-dir fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 "mcp>=1.28.1"
 
 # Copy the MCP server
 COPY gateway/ ./gateway/

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -819,12 +819,12 @@ SESSION_CWD="\$(pwd)"
     npm install -g "delimit-cli@\$LATE" >/dev/null 2>&1 && delimit-cli setup >/dev/null 2>&1; \\
   fi ) &
 DELIMIT_HOME="\${DELIMIT_HOME:-$HOME/.delimit}"
-TOOL_COUNT="0"
-if [ -f "$DELIMIT_HOME/server/ai/server.py" ]; then
-  DECORATED=$(grep -c '@mcp.tool' "$DELIMIT_HOME/server/ai/server.py" 2>/dev/null || echo "0")
-  IMPL=$(grep -c 'mcp.tool()(' "$DELIMIT_HOME/server/ai/server.py" 2>/dev/null || echo "0")
-  TOOL_COUNT=$((DECORATED + IMPL))
-fi
+# No tool count here: grepping @mcp.tool decorators over-counts what the
+# running server actually registers (tier/toolset gating), and a number the
+# user can compare against tools/list must agree (fresh-user install test
+# 2026-09-02, finding 6). Registration is not cheaply derivable from the file.
+MCP_STATUS="ready"
+[ -f "$DELIMIT_HOME/server/ai/server.py" ] || MCP_STATUS="not installed"
 echo ""
 printf "  \${PURPLE}\${BOLD}    ____  ________    ______  _____________\${RESET}\\n"
 printf "  \${PURPLE}\${BOLD}   / __ \\\\/ ____/ /   /  _/  |/  /  _/_  __/\${RESET}\\n"
@@ -837,7 +837,7 @@ echo ""
 printf "  \${PURPLE}\${BOLD}[Delimit]\${RESET} \${DIM}Executing governance check...\${RESET}\\n"
 sleep 0.1
 printf "  \${PURPLE}\${BOLD}[Delimit]\${RESET} \${ORANGE}Mode: advisory\${RESET}\\n"
-printf "  \${PURPLE}\${BOLD}[Delimit]\${RESET} \${DIM}MCP server: \${WHITE}\${TOOL_COUNT} tools\${RESET}\\n"
+printf "  \${PURPLE}\${BOLD}[Delimit]\${RESET} \${DIM}MCP server: \${WHITE}\${MCP_STATUS}\${RESET}\\n"
 printf "  \${MAGENTA}\${BOLD}[Delimit]\${RESET} \${MAGENTA}═══════════════════════════════════════════\${RESET}\\n"
 printf "  \${MAGENTA}\${BOLD}[Delimit]\${RESET} \${PURPLE}<\${MAGENTA}/\${ORANGE}>\${RESET} \${BOLD}GOVERNANCE ACTIVE: ${displayName.toUpperCase()}\${RESET}\\n"
 printf "  \${MAGENTA}\${BOLD}[Delimit]\${RESET} \${MAGENTA}═══════════════════════════════════════════\${RESET}\\n"
@@ -1375,12 +1375,8 @@ exit 127
         try {
             // Run the shim with DELIMIT_WRAPPED=true so it exits after banner
             // We simulate the banner directly instead
-            const toolCount = (() => {
-                try {
-                    const srv = fs.readFileSync(path.join(DELIMIT_HOME, 'server', 'ai', 'server.py'), 'utf-8');
-                    return (srv.match(/@mcp\.tool/g) || []).length + (srv.match(/mcp\.tool\(\)\(/g) || []).length;
-                } catch { return 0; }
-            })();
+            // Mirrors the shim: no decorator-derived tool count (over-counts vs tools/list).
+            const mcpStatus = fs.existsSync(path.join(DELIMIT_HOME, 'server', 'ai', 'server.py')) ? 'ready' : 'not installed';
             const version = require('../package.json').version;
             const purple = '\x1b[35m', magenta = '\x1b[91m', orange = '\x1b[33m';
             const bold2 = '\x1b[1m', dim2 = '\x1b[2m', reset = '\x1b[0m', green2 = '\x1b[32m';
@@ -1394,7 +1390,7 @@ exit 127
             console.log('');
             console.log(`  ${purple}${bold2}[Delimit]${reset} ${dim2}Executing governance check...${reset}`);
             console.log(`  ${purple}${bold2}[Delimit]${reset} ${orange}Mode: advisory${reset}`);
-            console.log(`  ${purple}${bold2}[Delimit]${reset} ${dim2}MCP server: ${toolCount} tools${reset}`);
+            console.log(`  ${purple}${bold2}[Delimit]${reset} ${dim2}MCP server: ${mcpStatus}${reset}`);
             console.log(`  ${magenta}${bold2}[Delimit]${reset} ${magenta}═══════════════════════════════════════════${reset}`);
             console.log(`  ${magenta}${bold2}[Delimit]${reset} ${purple}<${magenta}/${orange}>${reset} ${bold2}GOVERNANCE ACTIVE: CLAUDE${reset}`);
             console.log(`  ${magenta}${bold2}[Delimit]${reset} ${magenta}═══════════════════════════════════════════${reset}`);

--- a/tests/shim-renamed-binary.test.js
+++ b/tests/shim-renamed-binary.test.js
@@ -105,4 +105,19 @@ describe('shim: renamed <tool>-real binary is found on every launch path (LED-43
             assert.match(interactive, new RegExp(`/usr/bin/${tool}-real`), `${tool}: no -real fallback on the interactive path`);
         }
     });
+
+    // Fresh-user install test 2026-09-02, finding 6: the banner printed
+    // "MCP server: 229 tools" (count of @mcp.tool decorators + mcp.tool()()
+    // calls in server.py) while tools/list returned 210. A number the user can
+    // check must agree with the server, so the banner no longer carries one.
+    it('banner does not print a decorator-derived tool count', () => {
+        for (const tool of ['claude', 'codex', 'gemini']) {
+            const shim = renderShim(tool, tool);
+            const bannerLine = shim.split('\n').find((l) => l.startsWith('printf') && l.includes('MCP server:'));
+            assert.ok(bannerLine, `${tool}: MCP server banner line missing`);
+            assert.doesNotMatch(bannerLine, /TOOL_COUNT|\btools\b|[0-9]/, `${tool}: banner still carries a count: ${bannerLine}`);
+            assert.match(bannerLine, /MCP server: \$\{WHITE\}\$\{MCP_STATUS\}/);
+            assert.doesNotMatch(shim, /grep -c '@mcp\.tool'|grep -c 'mcp\.tool\(\)\('|TOOL_COUNT=/, `${tool}: shim still greps decorators to count tools`);
+        }
+    });
 });


### PR DESCRIPTION
## Why (LED-4391 findings 6 and 7 + PR #196 review note)
Numbers a new user can see disagreed: the governance shim banner said "MCP server: 229 tools" (a count of `@mcp.tool` decorators + `mcp.tool()(` calls in server.py) while `tools/list` returns 210 and Glama scores 209. The Dockerfile's pip fallback installed an unpinned fastmcp while `delimit setup` pins 3.1.0. The registry read-back URL passed the server name with an unencoded slash.

## What
- `bin/delimit-setup.js`: the shim banner prints "MCP server: ready" (or "not installed"); the two decorator greps and the count arithmetic are removed (the shim does strictly less work); the `delimit setup` banner preview mirrors the same text. The registered count is runtime-gated (toolsets, tiers) and not cheaply derivable from the file, so no number is printed rather than a wrong one.
- `Dockerfile`: fallback pinned to the same set `delimit setup` uses (`fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 "mcp>=1.28.1"`).
- `.github/workflows/registry-publish.yml`: `?search=` uses `encodeURIComponent(NAME)`; the exact-name match still compares the raw name. YAML parses.
- `tests/shim-renamed-binary.test.js`: new test renders the template for claude/codex/gemini and asserts the banner line carries no decorator-derived count and the shim contains no decorator grep (verified failing against the previous setup.js).

## Verification
Orchestrator re-ran `npm test`: 340 pass, 0 fail. `gateway/` untouched (the matching gateway change is delimit-ai/delimit-gateway PR, synced separately). Docker image not built. Panel note answered: the pinned set was resolved with pip's resolver on Python 3.10 (`pip install --dry-run`): 70 packages, fastmcp 3.1.0, pydantic 2.12.5, PyYAML 6.0.3, packaging 26.0, mcp 1.29.1, no conflict.

Consequence tier: LOW-MEDIUM (customer shim banner text, Docker fallback pin, CI workflow).

Head: 9588422805e5d27bfd5696a2d79301ec5f270ef9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
