### PR TITLE
fix(cli): close five fresh-install funnel leaks (wrap URL, TTY prompts, doctor version, check stderr, deliberate helpers) (LED-4391 #2-5)

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -4883,12 +4883,26 @@ program
             }
         }
         if (noCommitsYet) {
-            console.log(chalk.gray('  No commits yet, checking working-tree files (nothing to compare against for breaking changes).\n'));
-            try {
-                const output = execSync('git ls-files --cached --others --exclude-standard', gitOpts).trim();
-                if (output) changedFiles = output.split('\n');
-            } catch {
-                // Fall back to scanning known spec locations below
+            // --staged must keep the pre-commit hook's isolation on the very
+            // first commit: only the index counts, never untracked or
+            // unstaged files. `git diff --cached` diffs the index against
+            // the empty tree on an unborn HEAD, so it works here.
+            if (opts.staged) {
+                console.log(chalk.gray('  No commits yet, checking staged files (nothing to compare against for breaking changes).\n'));
+                try {
+                    const output = execSync('git diff --cached --name-only', gitOpts).trim();
+                    if (output) changedFiles = output.split('\n');
+                } catch {
+                    // Fall back to scanning known spec locations below
+                }
+            } else {
+                console.log(chalk.gray('  No commits yet, checking working-tree files (nothing to compare against for breaking changes).\n'));
+                try {
+                    const output = execSync('git ls-files --cached --others --exclude-standard', gitOpts).trim();
+                    if (output) changedFiles = output.split('\n');
+                } catch {
+                    // Fall back to scanning known spec locations below
+                }
             }
         } else {
             try {

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -35,6 +35,13 @@ const AGENT_URL = `http://127.0.0.1:${process.env.DELIMIT_AGENT_PORT || 7823}`;
 const program = new Command();
 
 const yaml = require('js-yaml');
+const { isInteractive } = require('../lib/interactive');
+
+// Single source of truth for the CLI's own version (package.json). Hardcoded
+// version strings in banners drift (doctor printed "v4.20" on a 4.18.1 install).
+const CLI_VERSION = (() => {
+    try { return require('../package.json').version; } catch { return 'unknown'; }
+})();
 
 const continuityContext = resolveContinuityContext();
 process.env.DELIMIT_HOME = continuityContext.delimitHome;
@@ -725,25 +732,20 @@ program
         }
         console.log(chalk.blue('Deliberating...'));
         console.log(chalk.gray(`Question: ${question}`));
-        try {
-            const result = execSync(
-                `python3 -c "import sys; sys.path.insert(0, '${continuityContext.serverDir}'); from ai.deliberation import deliberate; import json; r = deliberate(question='${question.replace(/'/g, "\\'")}'); print(json.dumps(r, indent=2))"`,
-                { encoding: 'utf-8', timeout: 120000, cwd: continuityContext.serverDir }
-            );
-            const parsed = JSON.parse(result);
-            if (parsed.error) {
-                console.log(chalk.red(`Error: ${parsed.error}`));
-            } else if (parsed.synthesis) {
-                console.log(chalk.green('\nConsensus:'));
-                console.log(parsed.synthesis);
-                if (parsed.verdict) console.log(chalk.blue(`\nVerdict: ${parsed.verdict}`));
-                if (parsed.confidence) console.log(chalk.gray(`Confidence: ${parsed.confidence}`));
-            } else {
-                console.log(JSON.stringify(parsed, null, 2));
-            }
-        } catch (e) {
-            console.log(chalk.red(`Deliberation failed: ${e.message}`));
+        // Same engine path as `delimit deliberate`: the venv python that
+        // `delimit setup` created, question passed via env (no shell quoting),
+        // and the engine's real result keys rendered. The previous inline
+        // python3 call could not import the compiled engine and printed keys
+        // (synthesis / confidence) the engine never returns.
+        const engine = resolveDeliberationEngine();
+        if (!engine) {
+            console.log(chalk.yellow('Deliberation engine not installed yet.'));
+            console.log(`Run ${chalk.cyan('delimit setup')} first (it installs the engine), then re-run this command.`);
+            console.log(`Inside your AI assistant you can still run ${chalk.cyan(`delimit_deliberate: ${question}`)}`);
+            return;
         }
+        const outcome = runEngineDeliberation(engine, question, { mode: 'dialogue', maxRounds: 2 });
+        renderDeliberationOutcome(outcome, question);
     });
 
 program
@@ -1677,7 +1679,18 @@ program
         const configDir = path.join(process.cwd(), '.delimit');
         const policyFile = path.join(configDir, 'policies.yml');
 
+        // Non-interactive runs (piped stdin, CI=1, DELIMIT_NON_INTERACTIVE)
+        // behave exactly like --yes: every prompt below is skipped and its
+        // documented default is used. Prevents hangs / exit 130 in scripts.
+        if (!options.yes && !isInteractive()) {
+            options.yes = true;
+            options.autoYes = true;
+        }
+
         console.log(chalk.bold('\n  Delimit — API Governance Setup\n'));
+        if (options.autoYes) {
+            console.log(chalk.gray('  Non-interactive session detected, using defaults (same as --yes).\n'));
+        }
 
         if (fs.existsSync(policyFile)) {
             console.log(chalk.yellow('  Already initialized — .delimit/policies.yml exists'));
@@ -2457,7 +2470,8 @@ program
         console.log(`    ${chalk.green('npx delimit-cli setup')}    — configure AI assistants\n`);
 
         // Beta capture (LED-263)
-        try {
+        // The beta email prompt is skipped silently when non-interactive.
+        if (isInteractive()) try {
             const betaAns = await inquirer.prompt([{
                 type: 'input',
                 name: 'email',
@@ -2566,7 +2580,8 @@ program
         console.log(chalk.gray(`  Clean up: rm -rf delimit-demo\n`));
 
         // Beta capture
-        try {
+        // The beta email prompt is skipped silently when non-interactive.
+        if (isInteractive()) try {
             const betaAns = await inquirer.prompt([{
                 type: 'input',
                 name: 'email',
@@ -2764,7 +2779,12 @@ program
                         console.log(`  ${chalk.yellow('→')} ${text}`);
                     });
                 }
-                // Interactive next step picker
+                // Interactive next step picker (skipped when stdin is not a
+                // terminal / CI: inquirer would exit 130 on a closed stdin).
+                if (!isInteractive()) {
+                    console.log(chalk.gray('\n  Next: npx delimit-cli lint <spec>  |  npx delimit-cli init  |  npx delimit-cli ci\n'));
+                    return;
+                }
                 try {
                     const { next } = await inquirer.prompt([{
                         type: 'list',
@@ -2900,7 +2920,11 @@ program
                 }
                 console.log('');
 
-                // Interactive next step picker
+                // Interactive next step picker (skipped when non-interactive;
+                // the readiness checklist above already names each fix command).
+                if (!isInteractive()) {
+                    return;
+                }
                 try {
                     // Pre-select the first missing item
                     const firstMissing = checks.find(c => !c.done);
@@ -3293,7 +3317,8 @@ program
         console.log(chalk.gray(`    rm delimit-report.md             — clean up this report\n`));
 
         // Beta capture
-        try {
+        // The beta email prompt is skipped silently when non-interactive.
+        if (isInteractive()) try {
             const betaAns = await inquirer.prompt([{
                 type: 'input',
                 name: 'email',
@@ -4109,7 +4134,7 @@ program
         }
 
         // --- Human-readable output ---
-        console.log(chalk.bold('\n  Delimit Doctor v4.20\n'));
+        console.log(chalk.bold(`\n  Delimit Doctor v${CLI_VERSION}\n`));
 
         const icons = { pass: chalk.green('  ✓'), warn: chalk.yellow('  ⚠'), fail: chalk.red('  ✗') };
         const colors = { pass: chalk.green, warn: chalk.yellow, fail: chalk.red };
@@ -4840,17 +4865,41 @@ program
             } catch {}
         }
 
-        // Find changed spec files via git
+        // Find changed spec files via git. All git calls here capture stderr
+        // (stdio pipe) so a raw "fatal: ambiguous argument 'HEAD'" never
+        // reaches the user; the friendly line below is what they see instead.
+        const gitOpts = { cwd: projectDir, encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] };
         const base = opts.base || 'HEAD';
         let changedFiles = [];
-        try {
-            const gitCmd = opts.staged
-                ? 'git diff --cached --name-only'
-                : `git diff --name-only ${base}`;
-            const output = execSync(gitCmd, { cwd: projectDir, encoding: 'utf-8', timeout: 5000 }).trim();
-            if (output) changedFiles = output.split('\n');
-        } catch {
-            // Not a git repo or no changes — fall back to scanning all specs
+        let noCommitsYet = false;
+        if (!opts.base) {
+            // A repo with no commits has no HEAD to diff against.
+            try {
+                execSync('git rev-parse --verify HEAD', gitOpts);
+            } catch (e) {
+                const msg = String((e && e.stderr) || (e && e.message) || '');
+                // Only an unborn HEAD qualifies; "not a git repo" keeps the old fallback.
+                if (/ambiguous argument|unknown revision|Needed a single revision|bad revision/i.test(msg)) noCommitsYet = true;
+            }
+        }
+        if (noCommitsYet) {
+            console.log(chalk.gray('  No commits yet, checking working-tree files (nothing to compare against for breaking changes).\n'));
+            try {
+                const output = execSync('git ls-files --cached --others --exclude-standard', gitOpts).trim();
+                if (output) changedFiles = output.split('\n');
+            } catch {
+                // Fall back to scanning known spec locations below
+            }
+        } else {
+            try {
+                const gitCmd = opts.staged
+                    ? 'git diff --cached --name-only'
+                    : `git diff --name-only ${base}`;
+                const output = execSync(gitCmd, gitOpts).trim();
+                if (output) changedFiles = output.split('\n');
+            } catch {
+                // Not a git repo or no changes — fall back to scanning all specs
+            }
         }
 
         // Filter to spec files
@@ -4900,8 +4949,9 @@ program
             // Get the base version from git
             let baseContent = null;
             try {
+                if (noCommitsYet) throw new Error('no base commit');
                 baseContent = execSync(`git show ${base}:${specFile}`, {
-                    cwd: projectDir, encoding: 'utf-8', timeout: 5000
+                    cwd: projectDir, encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'],
                 });
             } catch {
                 // File is new — no base version to compare
@@ -6125,11 +6175,28 @@ function resolveDeliberationEngine() {
         f === 'deliberation.py' || /^deliberation\.cpython-[^/]+\.(so|pyd)$/.test(f) || /^deliberation\.[^/]+\.(so|pyd)$/.test(f)
     );
     if (!hasEngine) return null;
-    const venvPython = homeSubpath('venv', 'bin', 'python');
+    // `delimit setup` creates the venv as ~/.delimit/venv; POSIX puts the
+    // interpreter under bin/, Windows under Scripts/ (matching the .pyd case
+    // above). Fall back to PATH python3 only when neither exists, and say so
+    // (a cpython-tagged compiled engine only imports under the interpreter it
+    // was built for, so the fallback usually cannot load it).
+    const candidates = [
+        homeSubpath('venv', 'bin', 'python'),
+        homeSubpath('venv', 'Scripts', 'python.exe'),
+    ];
+    const venvPython = candidates.find((p) => fs.existsSync(p));
     return {
         serverDir,
-        python: fs.existsSync(venvPython) ? venvPython : 'python3',
+        python: venvPython || (process.platform === 'win32' ? 'python' : 'python3'),
+        venv: !!venvPython,
     };
+}
+
+// Prepend the engine dir to any PYTHONPATH the user already has rather than
+// clobbering it (their site-packages / tooling must keep resolving).
+function withEnginePythonPath(serverDir) {
+    const existing = process.env.PYTHONPATH;
+    return existing ? `${serverDir}${path.delimiter}${existing}` : serverDir;
 }
 
 function runEngineDeliberation(engine, question, { mode = 'dialogue', maxRounds = 2 } = {}) {
@@ -6160,7 +6227,7 @@ function runEngineDeliberation(engine, question, { mode = 'dialogue', maxRounds 
         maxBuffer: 64 * 1024 * 1024,
         env: {
             ...process.env,
-            PYTHONPATH: engine.serverDir,
+            PYTHONPATH: withEnginePythonPath(engine.serverDir),
             DELIMIT_ENGINE_DIR: engine.serverDir,
             DELIMIT_Q: question,
             DELIMIT_MODE: mode,
@@ -6171,8 +6238,13 @@ function runEngineDeliberation(engine, question, { mode = 'dialogue', maxRounds 
     const stdout = proc.stdout || '';
     const marker = stdout.lastIndexOf('__DELIMIT_JSON__');
     if (proc.status !== 0 || marker < 0) {
-        const tail = ((proc.stderr || '') + '\n' + stdout).trim().split('\n').slice(-6).join('\n');
-        return { ran: false, error: tail || `engine exited with status ${proc.status}` };
+        let tail = ((proc.stderr || '') + '\n' + stdout).trim().split('\n').slice(-6).join('\n');
+        if (!tail) tail = `engine exited with status ${proc.status}`;
+        if (!engine.venv) {
+            tail += `\n(ran with ${engine.python} from PATH: no ~/.delimit/venv interpreter found. `
+                + 'The compiled engine is tagged to the Python that `delimit setup` installs; run `delimit setup` to restore it.)';
+        }
+        return { ran: false, error: tail };
     }
     try {
         return { ran: true, result: JSON.parse(stdout.slice(marker + '__DELIMIT_JSON__'.length)), savePath };
@@ -6665,8 +6737,18 @@ program
             }
             if (result.attestation_id) {
                 console.log();
+                // The local attestation file is the receipt. The hosted replay
+                // URL is printed only when the attestation was actually
+                // uploaded (replay_hosted); otherwise it would 404 and the
+                // first impression is "the receipt link is broken".
                 console.log(chalk.gray(`  attestation: ${result.attestation_path || '(not saved)'}`));
-                console.log(chalk.gray(`  replay:      ${result.replay_url}`));
+                if (result.replay_hosted) {
+                    console.log(chalk.gray(`  replay:      ${result.replay_url}`));
+                } else if (!result.tier || result.tier === 'free') {
+                    console.log(chalk.gray('  replay:      local only. Hosted, shareable replay is a Pro feature (https://delimit.ai/pricing)'));
+                } else {
+                    console.log(chalk.gray('  replay:      local only (this attestation was not uploaded)'));
+                }
             }
             if (result.handoff_suggestion) {
                 console.log();

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -6745,7 +6745,7 @@ program
                 if (result.replay_hosted) {
                     console.log(chalk.gray(`  replay:      ${result.replay_url}`));
                 } else if (!result.tier || result.tier === 'free') {
-                    console.log(chalk.gray('  replay:      local only. Hosted, shareable replay is a Pro feature (https://delimit.ai/pricing)'));
+                    console.log(chalk.gray('  replay:      not uploaded (local attestation only; hosted replay is not available yet)'));
                 } else {
                     console.log(chalk.gray('  replay:      local only (this attestation was not uploaded)'));
                 }

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -12,6 +12,11 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
+// Shared prompt gate: false when stdin/stdout is not a TTY, CI is set,
+// DELIMIT_NON_INTERACTIVE is set, or the user passed --yes. Every prompt
+// below falls back to its documented default when this is false.
+const { isInteractive } = require('../lib/interactive');
+const SETUP_INTERACTIVE = isInteractive({ yes: process.argv.includes('--yes') || process.argv.includes('-y') });
 const DELIMIT_HOME = path.join(os.homedir(), '.delimit');
 const MCP_CONFIG = path.join(os.homedir(), '.mcp.json');
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
@@ -134,7 +139,7 @@ async function main() {
     log(`  ${dim('Undo anytime:')} rm -rf ~/.delimit && delimit uninstall`);
     log('');
     const inquirerTop = (() => { try { return require('inquirer'); } catch { return null; } })();
-    if (inquirerTop && process.stdin.isTTY) {
+    if (inquirerTop && SETUP_INTERACTIVE) {
         try {
             const { proceed } = await inquirerTop.prompt([{
                 type: 'confirm',
@@ -496,7 +501,7 @@ async function main() {
     log(`    • Optional: governance wrapping + hooks`);
     log('');
     const inquirerMid = (() => { try { return require('inquirer'); } catch { return null; } })();
-    if (inquirerMid && process.stdin.isTTY) {
+    if (inquirerMid && SETUP_INTERACTIVE) {
         try {
             const { proceed } = await inquirerMid.prompt([{
                 type: 'confirm',
@@ -761,7 +766,7 @@ Run full governance compliance checks. Verify security, policy compliance, evide
         // First install — prompt
         const inquirer = (() => { try { return require('inquirer'); } catch { return null; } })();
         enableShims = true;
-        if (inquirer && process.stdin.isTTY) {
+        if (inquirer && SETUP_INTERACTIVE) {
             try {
                 const answer = await inquirer.prompt([{
                     type: 'confirm',
@@ -1055,7 +1060,7 @@ exit 127
             // Install hooks (auto-accept in non-interactive or prompt if TTY)
             let installHooks = true;
             const inq = (() => { try { return require('inquirer'); } catch { return null; } })();
-            if (inq && process.stdin.isTTY) {
+            if (inq && SETUP_INTERACTIVE) {
                 try {
                     const answer = await inq.prompt([{
                         type: 'confirm',

--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Shared "may I prompt the user?" decision for every CLI command.
+ *
+ * Fresh-install test 2026-09-02: `delimit scan` exited 130 on a closed stdin
+ * and `delimit init --preset default` still asked the compliance-template and
+ * "Join the beta?" questions under CI=1. Every prompt site must consult this
+ * helper and fall back to its documented default (the same behaviour as the
+ * existing `--yes` flag) when the answer is false.
+ *
+ * Non-interactive when ANY of:
+ *   - stdin or stdout is not a TTY (piped, closed, spawned by a script)
+ *   - CI is set (GitHub Actions, GitLab, Jenkins, etc. all set CI=1/true)
+ *   - DELIMIT_NON_INTERACTIVE is set (explicit opt-out for wrappers)
+ *   - the caller passed { yes: true } (the command's own --yes flag)
+ *
+ * @param {{ yes?: boolean }} [opts]
+ * @returns {boolean}
+ */
+function isInteractive(opts = {}) {
+    if (opts && opts.yes) return false;
+    const env = process.env;
+    if (env.DELIMIT_NON_INTERACTIVE && !['0', 'false', ''].includes(String(env.DELIMIT_NON_INTERACTIVE).toLowerCase())) return false;
+    if (env.CI && !['0', 'false', ''].includes(String(env.CI).toLowerCase())) return false;
+    if (!process.stdin || !process.stdin.isTTY) return false;
+    if (!process.stdout || !process.stdout.isTTY) return false;
+    return true;
+}
+
+module.exports = { isInteractive };

--- a/lib/wrap-engine.js
+++ b/lib/wrap-engine.js
@@ -252,9 +252,19 @@ function saveAttestation(att) {
 
 function replayUrl(attId) {
     // Public replay surface is served by app.delimit.ai (reuses the trust-page
-    // pattern from LED-1018). For MVP, just returns the URL; rendering + upload
-    // is the Pro-tier feature and not part of this MVP.
+    // pattern from LED-1018). This is the canonical address an attestation
+    // WOULD have once hosted; it resolves only after an upload. There is no
+    // upload path in this engine today, so the URL is a reference, not a
+    // receipt. Callers must consult `replay_hosted` before presenting it as a
+    // working link (fresh-install test 2026-09-02: free-tier users saw a 404).
     return `https://delimit.ai/att/${attId}`;
+}
+
+// Hosted replay is the Pro feature (rendering + upload). Nothing in this
+// engine uploads yet, so no attestation is hosted regardless of tier. When an
+// upload path lands, this is the single place to flip the answer.
+function isReplayHosted(/* attestation, tier */) {
+    return false;
 }
 
 // ----------------------------------------------------------------------------
@@ -498,6 +508,10 @@ async function runWrap(rawCmd, options = {}) {
         attestation_id: attId,
         attestation_path: filePath,
         replay_url: replayUrl(attId),
+        // true only when the attestation was actually uploaded and the
+        // replay_url resolves. Local-only attestations (every tier today)
+        // report false so callers never present a dead link as a receipt.
+        replay_hosted: isReplayHosted(attestation, quotaInfo ? quotaInfo.tier : null),
         kind,
         violations: governance.violations,
         gates: governance.gates,
@@ -519,4 +533,5 @@ module.exports = {
     signAttestation,
     checkQuota,
     replayUrl,
+    isReplayHosted,
 };

--- a/scripts/test-with-config-guard.js
+++ b/scripts/test-with-config-guard.js
@@ -45,6 +45,8 @@ const TEST_FILES = [
     'tests/bundle-parity-guard.test.js',
     'tests/chat-repl-prebrief.test.js',
     'tests/chat-repl-continuity.test.js',
+    'tests/cli-deliberate-runs-engine.test.js',
+    'tests/funnel-cli-leaks.test.js',
 ];
 
 const cfgPath = resolveSharedConfigPath();

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -1352,24 +1352,26 @@ describe('CLI deliberate command', () => {
         // this must use an empty HOME (no engine) or, on a developer box, it
         // would start a real multi-model panel from inside the test suite.
         const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-deliberate-pending-'));
-        const result = execSync(`node "${cliPath}" deliberate "Is this API change safe?" 2>&1`, {
-            encoding: 'utf-8',
-            timeout: 15000,
-            env: { ...process.env, HOME, DELIMIT_HOME: path.join(HOME, '.delimit') },
-        });
-        assert.ok(result.includes('Is this API change safe?'), 'Output should echo the question');
-        assert.ok(result.includes('delimit_deliberate'), 'Output should mention the MCP tool');
+        try {
+            const result = execSync(`node "${cliPath}" deliberate "Is this API change safe?" 2>&1`, {
+                encoding: 'utf-8',
+                timeout: 15000,
+                env: { ...process.env, HOME, DELIMIT_HOME: path.join(HOME, '.delimit') },
+            });
+            assert.ok(result.includes('Is this API change safe?'), 'Output should echo the question');
+            assert.ok(result.includes('delimit_deliberate'), 'Output should mention the MCP tool');
 
-        // Verify pending.json was created (engine absent -> question is parked)
-        const pendingPath = path.join(HOME, '.delimit', 'deliberation', 'pending.json');
-        assert.ok(fs.existsSync(pendingPath), 'pending.json should be created');
+            // Verify pending.json was created (engine absent -> question is parked)
+            const pendingPath = path.join(HOME, '.delimit', 'deliberation', 'pending.json');
+            assert.ok(fs.existsSync(pendingPath), 'pending.json should be created');
 
-        const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
-        assert.strictEqual(pending.question, 'Is this API change safe?');
-        assert.strictEqual(pending.status, 'pending');
-        assert.ok(pending.created, 'Should have a created timestamp');
-
-        // Clean up
-        try { fs.unlinkSync(pendingPath); } catch {}
+            const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
+            assert.strictEqual(pending.question, 'Is this API change safe?');
+            assert.strictEqual(pending.status, 'pending');
+            assert.ok(pending.created, 'Should have a created timestamp');
+        } finally {
+            // Remove the whole temp HOME, not just pending.json (it used to leak).
+            try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+        }
     });
 });

--- a/tests/funnel-cli-leaks.test.js
+++ b/tests/funnel-cli-leaks.test.js
@@ -1,0 +1,349 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+const { makeTmpGitRepo } = require('./_git-hermetic');
+
+/**
+ * Fresh-user install test of delimit-cli 4.18.1 (2026-09-02) found five
+ * install-funnel leaks. These tests pin the fixes:
+ *
+ *  1. `delimit wrap` printed a hosted replay URL that 404s on the free tier.
+ *  2. `delimit scan` / `delimit init` prompted (and exit 130) when stdin was
+ *     not a TTY or CI=1.
+ *  3. `delimit doctor` printed a hardcoded "v4.20" banner.
+ *  4. `delimit check` leaked raw git stderr in a repo with no commits.
+ *  5. `delimit deliberate` / `delimit think` engine-resolution fast-follows
+ *     from the PR #195 review.
+ */
+
+const CLI = path.join(__dirname, '..', 'bin', 'delimit-cli.js');
+const CLI_SRC = fs.readFileSync(CLI, 'utf-8');
+const PKG_VERSION = require('../package.json').version;
+const PETSTORE = path.join(__dirname, '..', 'examples', 'petstore-v1.yaml');
+
+const SKIP_IN_CI = process.env.CI ? 'requires full CLI stack (not available in CI)' : false;
+
+// Run the CLI with stdin CLOSED (not a pipe, not a TTY) and CI=1: the exact
+// shape of a scripted / container install.
+function runCli(args, { cwd, home, env = {}, timeout = 60000 } = {}) {
+    const delimitHome = path.join(home, '.delimit');
+    const res = spawnSync('node', [CLI, ...args], {
+        cwd,
+        encoding: 'utf-8',
+        timeout,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+            ...process.env,
+            HOME: home,
+            DELIMIT_HOME: delimitHome,
+            CI: '1',
+            NO_COLOR: '1',
+            ...env,
+        },
+    });
+    return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '', out: (res.stdout || '') + (res.stderr || '') };
+}
+
+function handlerSource(commandLiteral) {
+    const start = CLI_SRC.indexOf(`.command('${commandLiteral}')`);
+    assert.ok(start > 0, `${commandLiteral} command not found`);
+    return CLI_SRC.slice(start, CLI_SRC.indexOf(".command('", start + 10));
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper
+// ---------------------------------------------------------------------------
+
+describe('lib/interactive.isInteractive', () => {
+    const { isInteractive } = require('../lib/interactive');
+    const saved = {};
+    const KEYS = ['CI', 'DELIMIT_NON_INTERACTIVE'];
+
+    before(() => { for (const k of KEYS) { saved[k] = process.env[k]; delete process.env[k]; } });
+    after(() => { for (const k of KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+    it('is false when CI is set, whatever the TTY state', () => {
+        process.env.CI = 'true';
+        assert.equal(isInteractive(), false);
+        delete process.env.CI;
+    });
+
+    it('is false when DELIMIT_NON_INTERACTIVE is set', () => {
+        process.env.DELIMIT_NON_INTERACTIVE = '1';
+        assert.equal(isInteractive(), false);
+        delete process.env.DELIMIT_NON_INTERACTIVE;
+    });
+
+    it('is false when the caller passes yes (the --yes flag)', () => {
+        assert.equal(isInteractive({ yes: true }), false);
+    });
+
+    it('is false when stdin is not a TTY (the node --test runner pipes stdin)', () => {
+        if (process.stdin.isTTY && process.stdout.isTTY) return; // real terminal: nothing to assert
+        assert.equal(isInteractive(), false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 1. wrap: no dead replay link on the free tier
+// ---------------------------------------------------------------------------
+
+describe('delimit wrap: free-tier receipt is the local attestation, not a 404 URL', () => {
+    let repo;
+    let home;
+    before(() => {
+        repo = makeTmpGitRepo({ prefix: 'delimit-funnel-wrap-' });
+        home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-wrap-home-'));
+    });
+    after(() => { repo.cleanup(); try { fs.rmSync(home, { recursive: true, force: true }); } catch {} });
+
+    it('runWrap reports replay_hosted=false and keeps replay_url for compatibility', async () => {
+        const { runWrap, isReplayHosted } = require('../lib/wrap-engine');
+        const origHome = process.env.HOME;
+        process.env.HOME = home;
+        try {
+            const result = await runWrap(['echo', 'funnel-test'], { cwd: repo.dir });
+            assert.equal(typeof result.replay_url, 'string', 'replay_url stays in the JSON contract');
+            assert.equal(result.replay_hosted, false, 'nothing uploads today, so the URL must not be presented as resolving');
+            assert.equal(isReplayHosted(), false);
+        } finally {
+            process.env.HOME = origHome;
+        }
+    });
+
+    it('CLI prints the attestation path and a Pro note, never the delimit.ai/att URL, on the free tier', { skip: SKIP_IN_CI }, () => {
+        const r = runCli(['wrap', '--', 'echo', 'funnel-cli'], { cwd: repo.dir, home });
+        assert.equal(r.status, 0, r.out);
+        assert.match(r.stdout, /attestation:\s+\S+\.json/, 'local attestation path is the receipt');
+        assert.doesNotMatch(r.stdout, /delimit\.ai\/att\//, 'hosted replay URL must not be printed (it 404s)');
+        assert.match(r.stdout, /Pro feature/, 'says hosted replay is the Pro feature');
+        const replayLine = r.stdout.split('\n').find((l) => /^\s+replay:/.test(l)) || '';
+        assert.doesNotMatch(replayLine, /—/, 'no em dashes in the new user-facing string');
+    });
+
+    it('--json still carries replay_url plus the replay_hosted flag', { skip: SKIP_IN_CI }, () => {
+        const r = runCli(['wrap', '--json', '--', 'echo', 'funnel-json'], { cwd: repo.dir, home });
+        assert.equal(r.status, 0, r.out);
+        // The wrapped command's own stdout precedes the JSON document.
+        const parsed = JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+        assert.match(parsed.replay_url, /^https:\/\/delimit\.ai\/att\/att_/);
+        assert.equal(parsed.replay_hosted, false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. scan / init: never prompt when non-interactive
+// ---------------------------------------------------------------------------
+
+describe('delimit init / scan: non-interactive (closed stdin + CI=1) uses defaults and exits 0', () => {
+    let repo;
+    let home;
+    before(() => {
+        repo = makeTmpGitRepo({ prefix: 'delimit-funnel-init-' });
+        home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-init-home-'));
+        fs.copyFileSync(PETSTORE, path.join(repo.dir, 'openapi.yaml'));
+    });
+    after(() => { repo.cleanup(); try { fs.rmSync(home, { recursive: true, force: true }); } catch {} });
+
+    it('init writes .delimit/policies.yml without --yes and never asks "Join the beta"', { skip: SKIP_IN_CI }, () => {
+        const r = runCli(['init', '--preset', 'default'], { cwd: repo.dir, home });
+        assert.equal(r.status, 0, r.out);
+        assert.ok(fs.existsSync(path.join(repo.dir, '.delimit', 'policies.yml')), 'policies.yml must be written');
+        assert.doesNotMatch(r.out, /Join the beta/, 'beta email prompt must be skipped silently');
+        assert.doesNotMatch(r.out, /Compliance template/, 'compliance prompt must be skipped');
+        assert.match(r.stdout, /Created \.delimit\/policies\.yml \(default\)/);
+    });
+
+    it('init with no preset flag also completes on the documented default', { skip: SKIP_IN_CI }, () => {
+        const other = makeTmpGitRepo({ prefix: 'delimit-funnel-init2-' });
+        try {
+            fs.copyFileSync(PETSTORE, path.join(other.dir, 'openapi.yaml'));
+            const r = runCli(['init'], { cwd: other.dir, home });
+            assert.equal(r.status, 0, r.out);
+            assert.ok(fs.existsSync(path.join(other.dir, '.delimit', 'policies.yml')));
+            assert.match(r.stdout, /\(default\)/);
+        } finally {
+            other.cleanup();
+        }
+    });
+
+    it('scan of a project directory exits 0 and does not open the "What next?" picker', { skip: SKIP_IN_CI }, () => {
+        const r = runCli(['scan'], { cwd: repo.dir, home, timeout: 90000 });
+        assert.equal(r.status, 0, `scan must not exit 130/non-zero on closed stdin:\n${r.out}`);
+        assert.doesNotMatch(r.out, /What next\?/);
+        assert.match(r.stdout, /Governance Readiness/);
+    });
+
+    it('scan of a spec file exits 0 and prints the next-step hint instead of prompting', { skip: SKIP_IN_CI }, () => {
+        const r = runCli(['scan', 'openapi.yaml'], { cwd: repo.dir, home, timeout: 90000 });
+        assert.equal(r.status, 0, r.out);
+        assert.doesNotMatch(r.out, /What next\?/);
+    });
+
+    it('init honours DELIMIT_NON_INTERACTIVE even without CI', { skip: SKIP_IN_CI }, () => {
+        const other = makeTmpGitRepo({ prefix: 'delimit-funnel-init3-' });
+        try {
+            const r = runCli(['init'], { cwd: other.dir, home, env: { CI: '', DELIMIT_NON_INTERACTIVE: '1' } });
+            assert.equal(r.status, 0, r.out);
+            assert.ok(fs.existsSync(path.join(other.dir, '.delimit', 'policies.yml')));
+            assert.doesNotMatch(r.out, /Join the beta/);
+        } finally {
+            other.cleanup();
+        }
+    });
+
+    it('setup and the demo/quickstart/try beta prompts route through the shared helper (source pin)', () => {
+        const setupSrc = fs.readFileSync(path.join(__dirname, '..', 'bin', 'delimit-setup.js'), 'utf-8');
+        assert.doesNotMatch(setupSrc, /process\.stdin\.isTTY/, 'setup must use isInteractive(), not a bare isTTY check');
+        assert.match(setupSrc, /require\('\.\.\/lib\/interactive'\)/);
+        const betaSites = CLI_SRC.split('Join the beta?').length - 1;
+        assert.ok(betaSites >= 4, 'expected the four beta prompt sites to still exist');
+        assert.equal((CLI_SRC.match(/if \(isInteractive\(\)\) try \{/g) || []).length, 3, 'demo/quickstart/try beta prompts gated');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. doctor: version comes from package.json
+// ---------------------------------------------------------------------------
+
+describe('delimit doctor: banner version is derived from package.json', () => {
+    it('prints the real CLI version and no hardcoded v4.20', { skip: SKIP_IN_CI }, () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-doctor-home-'));
+        const repo = makeTmpGitRepo({ prefix: 'delimit-funnel-doctor-' });
+        try {
+            const r = runCli(['doctor'], { cwd: repo.dir, home, timeout: 90000 });
+            assert.ok(r.stdout.includes(`Delimit Doctor v${PKG_VERSION}`), `expected v${PKG_VERSION} in:\n${r.out}`);
+            if (PKG_VERSION !== '4.20') assert.doesNotMatch(r.stdout, /Doctor v4\.20\b/);
+        } finally {
+            repo.cleanup();
+            try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+        }
+    });
+
+    it('source no longer carries a literal doctor version', () => {
+        assert.doesNotMatch(CLI_SRC, /Delimit Doctor v\d/);
+        assert.match(CLI_SRC, /Delimit Doctor v\$\{CLI_VERSION\}/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 4. check: no raw git stderr in a repo with no commits
+// ---------------------------------------------------------------------------
+
+describe('delimit check: repo with no commits', () => {
+    it('prints one friendly line and never leaks "fatal: ambiguous argument"', { skip: SKIP_IN_CI }, () => {
+        const repo = makeTmpGitRepo({ prefix: 'delimit-funnel-check-', commit: false });
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-check-home-'));
+        try {
+            fs.copyFileSync(PETSTORE, path.join(repo.dir, 'openapi.yaml'));
+            const r = runCli(['check'], { cwd: repo.dir, home });
+            assert.equal(r.status, 0, r.out);
+            assert.doesNotMatch(r.out, /fatal:/, 'raw git stderr must not reach the user');
+            assert.doesNotMatch(r.out, /ambiguous argument/);
+            assert.match(r.stdout, /No commits yet/);
+            assert.match(r.stdout, /openapi\.yaml/, 'working-tree spec is still examined');
+        } finally {
+            repo.cleanup();
+            try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+        }
+    });
+
+    it('still diffs against HEAD in a repo that has commits', { skip: SKIP_IN_CI }, () => {
+        const repo = makeTmpGitRepo({ prefix: 'delimit-funnel-check2-' });
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-check2-home-'));
+        try {
+            fs.copyFileSync(PETSTORE, path.join(repo.dir, 'openapi.yaml'));
+            repo.run('git add . && git commit -qm spec');
+            const r = runCli(['check'], { cwd: repo.dir, home });
+            assert.doesNotMatch(r.out, /fatal:/);
+            assert.doesNotMatch(r.stdout, /No commits yet/);
+        } finally {
+            repo.cleanup();
+            try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 5. deliberate / think helpers (PR #195 review fast-follows)
+// ---------------------------------------------------------------------------
+
+describe('delimit deliberate / think: engine helper fast-follows', () => {
+    it('resolver also looks for venv/Scripts/python.exe (the .pyd match implies Windows)', () => {
+        const start = CLI_SRC.indexOf('function resolveDeliberationEngine(');
+        const body = CLI_SRC.slice(start, start + 2500);
+        assert.match(body, /'Scripts', 'python\.exe'/);
+        assert.match(body, /'bin', 'python'/);
+        assert.match(body, /venv:/, 'engine object records whether the venv interpreter was found');
+    });
+
+    it('PYTHONPATH is prepended to, not overwritten', () => {
+        const start = CLI_SRC.indexOf('function withEnginePythonPath(');
+        assert.ok(start > 0, 'withEnginePythonPath helper missing');
+        const body = CLI_SRC.slice(start, start + 600);
+        assert.match(body, /process\.env\.PYTHONPATH/);
+        assert.match(body, /path\.delimiter/);
+        const run = CLI_SRC.slice(CLI_SRC.indexOf('function runEngineDeliberation('), CLI_SRC.indexOf('function renderDeliberationOutcome('));
+        assert.match(run, /PYTHONPATH: withEnginePythonPath\(engine\.serverDir\)/);
+    });
+
+    it('error tail hints at `delimit setup` when the PATH python fallback was used', () => {
+        const run = CLI_SRC.slice(CLI_SRC.indexOf('function runEngineDeliberation('), CLI_SRC.indexOf('function renderDeliberationOutcome('));
+        assert.match(run, /if \(!engine\.venv\)/);
+        assert.match(run, /delimit setup/);
+    });
+
+    it('`delimit think` routes through the shared engine helpers', () => {
+        const handler = handlerSource('think [question...]');
+        assert.doesNotMatch(handler, /python3 -c/, 'no inline python3 shell call');
+        assert.doesNotMatch(handler, /parsed\.synthesis|parsed\.confidence/, 'no keys the engine does not return');
+        assert.match(handler, /resolveDeliberationEngine\(\)/);
+        assert.match(handler, /runEngineDeliberation\(/);
+        assert.match(handler, /renderDeliberationOutcome\(/);
+    });
+
+    it('think + deliberate run the venv interpreter with PYTHONPATH prepended (stub engine)', { skip: SKIP_IN_CI || process.platform === 'win32' }, () => {
+        const py = spawnSync('python3', ['--version'], { encoding: 'utf-8' });
+        if (py.status !== 0) return; // no python3 on this box: nothing to exercise
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-think-home-'));
+        try {
+            const dh = path.join(home, '.delimit');
+            const aiDir = path.join(dh, 'server', 'ai');
+            fs.mkdirSync(aiDir, { recursive: true });
+            fs.writeFileSync(path.join(aiDir, '__init__.py'), '');
+            fs.writeFileSync(path.join(aiDir, 'deliberation.py'), [
+                'def deliberate(question, mode="dialogue", max_rounds=2, save_path=None):',
+                '    return {"final_verdict": "STUB VERDICT", "rounds": [1], "models_used": ["stub"], "summary": "stub summary for " + question}',
+                '',
+            ].join('\n'));
+            // Fake venv python: records PYTHONPATH then delegates to the real interpreter.
+            const venvBin = path.join(dh, 'venv', 'bin');
+            fs.mkdirSync(venvBin, { recursive: true });
+            const recorder = path.join(home, 'pythonpath.txt');
+            const fakePython = path.join(venvBin, 'python');
+            fs.writeFileSync(fakePython, `#!/bin/sh\nprintf '%s' "$PYTHONPATH" > "${recorder}"\nexec python3 "$@"\n`);
+            fs.chmodSync(fakePython, 0o755);
+
+            const preexisting = '/opt/user/site-packages';
+            const r = runCli(['think', 'Is the stub engine wired?'], { cwd: home, home, env: { PYTHONPATH: preexisting } });
+            assert.equal(r.status, 0, r.out);
+            assert.match(r.stdout, /Verdict: STUB VERDICT/, 'renders the engine\'s real verdict key');
+            assert.match(r.stdout, /stub summary for Is the stub engine wired\?/);
+            assert.ok(fs.existsSync(recorder), 'the venv interpreter (not PATH python3) must have been used');
+            const recorded = fs.readFileSync(recorder, 'utf-8');
+            const serverDir = path.join(dh, 'server');
+            assert.equal(recorded, `${serverDir}${path.delimiter}${preexisting}`, 'engine dir prepended to the existing PYTHONPATH');
+
+            fs.unlinkSync(recorder);
+            const d = runCli(['deliberate', 'Is the stub engine wired?'], { cwd: home, home, env: { PYTHONPATH: preexisting } });
+            assert.equal(d.status, 0, d.out);
+            assert.match(d.stdout, /Verdict: STUB VERDICT/);
+            assert.equal(fs.readFileSync(recorder, 'utf-8'), `${serverDir}${path.delimiter}${preexisting}`);
+        } finally {
+            try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+        }
+    });
+});

--- a/tests/funnel-cli-leaks.test.js
+++ b/tests/funnel-cli-leaks.test.js
@@ -114,12 +114,12 @@ describe('delimit wrap: free-tier receipt is the local attestation, not a 404 UR
         }
     });
 
-    it('CLI prints the attestation path and a Pro note, never the delimit.ai/att URL, on the free tier', { skip: SKIP_IN_CI }, () => {
+    it('CLI prints the attestation path and a not-uploaded note, never the delimit.ai/att URL, on the free tier', { skip: SKIP_IN_CI }, () => {
         const r = runCli(['wrap', '--', 'echo', 'funnel-cli'], { cwd: repo.dir, home });
         assert.equal(r.status, 0, r.out);
         assert.match(r.stdout, /attestation:\s+\S+\.json/, 'local attestation path is the receipt');
         assert.doesNotMatch(r.stdout, /delimit\.ai\/att\//, 'hosted replay URL must not be printed (it 404s)');
-        assert.match(r.stdout, /Pro feature/, 'says hosted replay is the Pro feature');
+        assert.match(r.stdout, /not available yet/, 'says hosted replay is not available yet, promising nothing to any tier');
         const replayLine = r.stdout.split('\n').find((l) => /^\s+replay:/.test(l)) || '';
         assert.doesNotMatch(replayLine, /—/, 'no em dashes in the new user-facing string');
     });

--- a/tests/funnel-cli-leaks.test.js
+++ b/tests/funnel-cli-leaks.test.js
@@ -1,4 +1,5 @@
 const { describe, it, before, after } = require('node:test');
+const { execSync } = require('child_process');
 const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
@@ -344,6 +345,34 @@ describe('delimit deliberate / think: engine helper fast-follows', () => {
             assert.equal(fs.readFileSync(recorder, 'utf-8'), `${serverDir}${path.delimiter}${preexisting}`);
         } finally {
             try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+        }
+    });
+});
+
+
+describe('delimit check --staged on an unborn HEAD keeps pre-commit isolation (PR #199 review)', () => {
+    it('sees only the staged spec, never an untracked or unstaged one', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-unborn-staged-'));
+        const dir = path.join(home, 'repo');
+        fs.mkdirSync(dir, { recursive: true });
+        try {
+            execSync('git init -q', { cwd: dir });
+            const spec = (title) => `openapi: 3.0.0\ninfo:\n  title: ${title}\n  version: 1.0.0\npaths: {}\n`;
+            fs.writeFileSync(path.join(dir, 'staged-openapi.yaml'), spec('staged'));
+            fs.writeFileSync(path.join(dir, 'untracked-openapi.yaml'), spec('untracked'));
+            execSync('git add staged-openapi.yaml', { cwd: dir });
+            const r = spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'check', '--staged'], {
+                cwd: dir, encoding: 'utf-8', timeout: 60000,
+                env: { ...process.env, HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            const out = r.stdout + r.stderr;
+            assert.doesNotMatch(out, /fatal:/, 'no raw git error');
+            assert.match(out, /checking staged files/, 'says it is checking staged files on an unborn HEAD');
+            assert.match(out, /staged-openapi\.yaml/, 'the staged spec is checked');
+            assert.doesNotMatch(out, /untracked-openapi\.yaml/, 'an untracked spec must not leak into a --staged run');
+        } finally {
+            fs.rmSync(home, { recursive: true, force: true });
         }
     });
 });


### PR DESCRIPTION
## Why (LED-4391 findings 2–5 + PR #195 review fast-follows)
Fresh-user install test of 4.18.1 in an empty container (report: `DELIMIT_FRESH_USER_INSTALL_TEST_2026-09-02.md`): `delimit wrap` printed a replay URL that 404s; `scan`/`init` prompted with no terminal and `scan` exited 130 on closed stdin; `doctor` said "v4.20" on 4.18.1; `check` on a commit-less repo leaked raw git stderr.

## What
- **wrap**: `replay_hosted` field (false: no tier uploads today); the receipt line prints the local attestation path and "not uploaded (local attestation only; hosted replay is not available yet)". No URL is printed for any tier until an upload path exists. `replay_url` unchanged in JSON.
- **Non-interactive**: new `lib/interactive.js` `isInteractive()` (false under `--yes`, `DELIMIT_NON_INTERACTIVE`, `CI`, or non-TTY stdin/stdout). `init` coerces `--yes` when non-interactive; `scan` skips its pickers; demo/quickstart/try "Join the beta" prompts gated; `delimit-setup.js` TTY checks unified.
- **doctor**: version from package.json.
- **check**: unborn HEAD detected via `git rev-parse --verify HEAD`; prints one friendly line, scans working-tree files via `git ls-files`; all git calls pipe stderr.
- **deliberate/think**: resolver tries `venv/bin/python` then `venv/Scripts/python.exe`; PYTHONPATH prepended, not overwritten; python3-fallback hint; `think` routed through the same helpers; pending.json test cleans its temp HOME.
- **Test runner**: `tests/cli-deliberate-runs-engine.test.js` (from #195) was never listed in `scripts/test-with-config-guard.js` TEST_FILES, so it had not been running in CI. Registered, plus the new `tests/funnel-cli-leaks.test.js` (22 cases).

## Verification (orchestrator, independent of the agent)
`npm test`: 367 pass, 0 fail. Live in a fresh temp HOME: `check` on a no-commit repo → "No commits yet, checking working-tree files…", no `fatal:`, exit 0; `init --preset default` with stdin closed + CI=1 → exit 0, policies.yml written, zero prompts; `doctor` → "Delimit Doctor v4.18.2"; `wrap -- echo hi` → local path + "not uploaded" line, no delimit.ai/att URL. `gateway/` untouched.

Consequence tier: MEDIUM (customer CLI behaviour; all additive, no flag removed).

Head: 62390886c1a23c1410557ef35d210ddadf856ffc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT

## Review round 1 — disposition
Unanimous BLOCK on one concrete defect: `check --staged` on an unborn HEAD used `git ls-files --cached --others`, pulling untracked/unstaged files into a pre-commit hook run on the first commit. FIXED: with `--staged` the no-commits path now diffs the index against the empty tree (`git diff --cached --name-only`); without `--staged` working-tree discovery stays. New test: staged spec checked, untracked spec excluded. Everything else was judged merge-ready.
