### PR TITLE
sync(gateway): serverInfo.version from the VERSION marker; fastmcp pinned 3.1.0 (from gateway bb690ec)

### DIFF
--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -581,7 +581,60 @@ def _emit_policy_event(tool_name: str, status: str, reason: str) -> None:
         pass  # Never let event tracking break tool execution
 
 
-mcp = FastMCP("delimit")
+# Version truth (LED-1889): the served version is DERIVED, never hand-edited.
+# Canonical source = the delimit-cli package manifest this server ships inside.
+# Resolution order (first hit wins), walking up from this file:
+#   1. a `VERSION` marker file (written into the bundle / installed
+#      ~/.delimit/server tree at publish/sync time)
+#   2. a `package.json` whose name is `delimit-cli` (npm bundle layout:
+#      gateway/ai/server.py ← ../../package.json)
+#   3. the pinned fallback below (last resort so the delimit_version return
+#      schema never changes shape — never-break-installs).
+_VERSION_FALLBACK = "4.15.0"
+
+
+def _resolve_version(start_path: Optional[str] = None) -> str:
+    """Resolve the shipped package version from the bundle's own manifest.
+
+    Read-only; any I/O or parse failure falls back to _VERSION_FALLBACK.
+    """
+    try:
+        here = Path(start_path or __file__).resolve()
+        for parent in list(here.parents)[:4]:
+            marker = parent / "VERSION"
+            if marker.is_file():
+                candidate = marker.read_text(encoding="utf-8").strip()
+                if candidate:
+                    return candidate
+            pkg = parent / "package.json"
+            if pkg.is_file():
+                try:
+                    data = json.loads(pkg.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                if data.get("name") == "delimit-cli" and data.get("version"):
+                    return str(data["version"])
+    except Exception:
+        pass
+    return _VERSION_FALLBACK
+
+
+VERSION = _resolve_version()
+
+
+def _construct_mcp(name: str, version: str):
+    """Build the FastMCP app so the MCP ``initialize`` handshake reports OUR
+    version. Without ``version=`` fastmcp advertises its own library version
+    as ``serverInfo.version`` (fresh-user install test 2026-09-02, finding 6:
+    "3.1.0" on a setup venv, "4.0.2" in Docker). Older fastmcp releases
+    without the kwarg must still start (never-break-installs)."""
+    try:
+        return FastMCP(name, version=version)
+    except TypeError:
+        return FastMCP(name)
+
+
+mcp = _construct_mcp("delimit", VERSION)
 
 def _auto_configure_antigravity():
     try:
@@ -646,45 +699,6 @@ mcp.description = (
     "Use delimit_scan on new projects. Track all work via the ledger."
 )
 
-# Version truth (LED-1889): the served version is DERIVED, never hand-edited.
-# Canonical source = the delimit-cli package manifest this server ships inside.
-# Resolution order (first hit wins), walking up from this file:
-#   1. a `VERSION` marker file (written into the bundle / installed
-#      ~/.delimit/server tree at publish/sync time)
-#   2. a `package.json` whose name is `delimit-cli` (npm bundle layout:
-#      gateway/ai/server.py ← ../../package.json)
-#   3. the pinned fallback below (last resort so the delimit_version return
-#      schema never changes shape — never-break-installs).
-_VERSION_FALLBACK = "4.15.0"
-
-
-def _resolve_version(start_path: Optional[str] = None) -> str:
-    """Resolve the shipped package version from the bundle's own manifest.
-
-    Read-only; any I/O or parse failure falls back to _VERSION_FALLBACK.
-    """
-    try:
-        here = Path(start_path or __file__).resolve()
-        for parent in list(here.parents)[:4]:
-            marker = parent / "VERSION"
-            if marker.is_file():
-                candidate = marker.read_text(encoding="utf-8").strip()
-                if candidate:
-                    return candidate
-            pkg = parent / "package.json"
-            if pkg.is_file():
-                try:
-                    data = json.loads(pkg.read_text(encoding="utf-8"))
-                except (json.JSONDecodeError, OSError):
-                    continue
-                if data.get("name") == "delimit-cli" and data.get("version"):
-                    return str(data["version"])
-    except Exception:
-        pass
-    return _VERSION_FALLBACK
-
-
-VERSION = _resolve_version()
 
 # LED-044 + Consensus 118/119/120: Tool visibility tiers.
 # Tier cascade: SHOW_EXPERIMENTAL > SHOW_INTERNAL > SHOW_OPS > public (always visible).

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -8,7 +8,15 @@
 # fresh `delimit setup` installed only the 3 lines below, the fastmcp fallback
 # in delimit-setup.js never fired, and `import fastmcp` in ai/server.py killed
 # the MCP server on every clean install. Adding it closes that never-break-installs gap.
-fastmcp>=3.0
+#
+# Exact pin (fresh-user install test 2026-09-02, finding 7): `delimit setup`
+# resolves this file into its venv while the Docker image fell through to an
+# unpinned fallback, so the two surfaces ran different fastmcp majors ("3.1.0"
+# vs "4.0.2"). One version everywhere: this pin, the delimit-setup.js no-reqfile
+# fallback, and the Dockerfile fallback MUST all say the same fastmcp.
+# 3.1.0 accepts FastMCP(version=...) (serverInfo.version) and constrains
+# mcp<2.0,>=1.24.0, so the LED-3840 floor below still resolves.
+fastmcp==3.1.0
 pydantic>=2.0.0
 pyyaml>=6.0
 packaging>=23.0


### PR DESCRIPTION
## Why
Carries delimit-ai/delimit-gateway#416 (unanimous 4/3, merged bb690ec) into the public bundle: the MCP `initialize` handshake reports Delimit's version from `gateway/VERSION` instead of the fastmcp library version (a fresh install reported "3.1.0", a Docker build "4.0.2" — LED-4391 finding 6), and `requirements.txt` pins `fastmcp==3.1.0` to match `delimit-setup.js` and the Dockerfile fallback merged in #198 (finding 7).

## What
Sync-only. `gateway/ai/server.py` (version block above construction; `_construct_mcp(name, version)` with a TypeError fallback for older fastmcp) and `gateway/requirements.txt` (`fastmcp==3.1.0`). No other bundle file changed; classification guard green; `server.py` byte-identical to gateway bb690ec.

## Verification
Gateway side: 20 tests incl. an end-to-end stdio handshake against a bundle-shaped copy with a VERSION marker. The pinned set resolves with pip (70 packages, no conflict). Bundle-layout check by the orchestrator: the synced `gateway/` tree from this branch (ai/ beside `VERSION` = 4.18.2) answers a stdio `initialize` with `serverInfo {'name': 'delimit', 'version': '4.18.2'}`.

Consequence tier: MEDIUM (already reviewed content). Ships with the next npm release.

Head: 2d296805a485b97c830833c6d431d74cfaa44392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
