### PR TITLE
fix(check): an empty --staged index is authoritative; run the check tests on CI (#199 r2 follow-ups)

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -4872,6 +4872,11 @@ program
         const base = opts.base || 'HEAD';
         let changedFiles = [];
         let noCommitsYet = false;
+        // True once `git diff --cached` has answered for a --staged run. An
+        // EMPTY answer is then authoritative: nothing is staged, so the
+        // known-location spec scan below must not pull unstaged or untracked
+        // files into a pre-commit check (PR #199 review follow-up).
+        let stagedListed = false;
         if (!opts.base) {
             // A repo with no commits has no HEAD to diff against.
             try {
@@ -4892,6 +4897,7 @@ program
                 try {
                     const output = execSync('git diff --cached --name-only', gitOpts).trim();
                     if (output) changedFiles = output.split('\n');
+                    stagedListed = true;
                 } catch {
                     // Fall back to scanning known spec locations below
                 }
@@ -4911,6 +4917,7 @@ program
                     : `git diff --name-only ${base}`;
                 const output = execSync(gitCmd, gitOpts).trim();
                 if (output) changedFiles = output.split('\n');
+                if (opts.staged) stagedListed = true;
             } catch {
                 // Not a git repo or no changes — fall back to scanning all specs
             }
@@ -4931,8 +4938,10 @@ program
             } catch { return false; }
         });
 
-        // If no changed specs found, scan all known specs
-        if (specFiles.length === 0) {
+        // If no changed specs found, scan all known specs. Not for a --staged
+        // run whose index listing succeeded: an empty index means nothing to
+        // check, and scanning the tree would leak unstaged files into a hook.
+        if (specFiles.length === 0 && !(opts.staged && stagedListed)) {
             const candidates = [
                 'api/openapi.yaml', 'api/openapi.yml', 'api/openapi.json',
                 'openapi.yaml', 'openapi.yml', 'openapi.json',

--- a/tests/funnel-cli-leaks.test.js
+++ b/tests/funnel-cli-leaks.test.js
@@ -235,7 +235,7 @@ describe('delimit doctor: banner version is derived from package.json', () => {
 // ---------------------------------------------------------------------------
 
 describe('delimit check: repo with no commits', () => {
-    it('prints one friendly line and never leaks "fatal: ambiguous argument"', { skip: SKIP_IN_CI }, () => {
+    it('prints one friendly line and never leaks "fatal: ambiguous argument"', { skip: false /* git + node only: runs on CI */ }, () => {
         const repo = makeTmpGitRepo({ prefix: 'delimit-funnel-check-', commit: false });
         const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-check-home-'));
         try {
@@ -252,7 +252,7 @@ describe('delimit check: repo with no commits', () => {
         }
     });
 
-    it('still diffs against HEAD in a repo that has commits', { skip: SKIP_IN_CI }, () => {
+    it('still diffs against HEAD in a repo that has commits', { skip: false /* git + node only: runs on CI */ }, () => {
         const repo = makeTmpGitRepo({ prefix: 'delimit-funnel-check2-' });
         const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-funnel-check2-home-'));
         try {
@@ -375,4 +375,37 @@ describe('delimit check --staged on an unborn HEAD keeps pre-commit isolation (P
             fs.rmSync(home, { recursive: true, force: true });
         }
     });
+});
+
+
+describe('delimit check --staged: an empty index is authoritative (PR #199 r2 follow-up)', () => {
+    function repo(withCommit) {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-empty-staged-'));
+        const dir = path.join(home, 'repo'); fs.mkdirSync(dir, { recursive: true });
+        execSync('git init -q', { cwd: dir });
+        if (withCommit) {
+            fs.writeFileSync(path.join(dir, 'README.md'), 'x\n');
+            execSync('git add README.md && git -c user.email=t@e.c -c user.name=t commit -qm init', { cwd: dir });
+        }
+        // An UNTRACKED spec at a known location: the old fallback would have scanned it.
+        fs.writeFileSync(path.join(dir, 'openapi.yaml'), 'openapi: 3.0.0\ninfo:\n  title: untracked\n  version: 1.0.0\npaths: {}\n');
+        return { home, dir };
+    }
+    function run(dir, home) {
+        return spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'check', '--staged'], {
+            cwd: dir, encoding: 'utf-8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
+        });
+    }
+    for (const [label, withCommit] of [['unborn HEAD', false], ['repo with commits', true]]) {
+        it(`${label}: nothing staged means nothing checked, the untracked spec is not scanned`, () => {
+            const { home, dir } = repo(withCommit);
+            try {
+                const r = run(dir, home); const out = r.stdout + r.stderr;
+                assert.strictEqual(r.status, 0, out);
+                assert.doesNotMatch(out, /openapi\.yaml/, 'untracked spec leaked into an empty --staged run');
+                assert.match(out, /Nothing to check/);
+            } finally { fs.rmSync(home, { recursive: true, force: true }); }
+        });
+    }
 });


### PR DESCRIPTION
## Why (PR #199 round-2 panel follow-ups)
Codex found, and the panel agreed, that `delimit check --staged` treats an EMPTY index like a git failure: it falls through to scanning known spec locations, which can pull an unstaged or untracked spec into a pre-commit hook run. Pre-existing on main (not a #199 regression), so it was merged as a follow-up. The panel also noted the new `check` runtime tests were skipped on CI.

## What
- `bin/delimit-cli.js`: `stagedListed` is set once `git diff --cached` answers for a `--staged` run (unborn HEAD and normal paths); the known-location scan is skipped when `opts.staged && stagedListed`. Non-staged runs are unchanged.
- `tests/funnel-cli-leaks.test.js`: two new cases (unborn HEAD, repo with commits): an untracked `openapi.yaml` at a known location, nothing staged, `check --staged` exits 0, prints "Nothing to check", never names the file. The two existing `check` tests that need only git and node now run on CI (`skip: false`).

## Verification
`npm test` locally: all green (count in the PR checks). Both new cases verified failing-by-construction reasoning: the old fallback scanned `openapi.yaml` at the repo root.

Consequence tier: LOW-MEDIUM (customer CLI, additive; narrows a scan only for `--staged`).

Head: 782a8b381b6708c66c589931c5be6a3658b06608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
