### PR TITLE
fix(check): fail closed on engine errors; zero-config YAML without PyYAML (P0 LED-4423)

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -2743,13 +2743,26 @@ program
             return;
         }
 
-        // Check Python + yaml dependency
+        // Check Python + yaml dependency. Scoring below no longer needs PyYAML
+        // (specs are parsed in node and handed to python as JSON), so a refused
+        // install (PEP 668 on Debian 12) is reported in one line, never a
+        // Traceback, and scan carries on.
         try {
             execSync('python3 -c "import yaml"', { stdio: 'ignore', timeout: 5000 });
         } catch {
             console.log(chalk.yellow('  Installing Python dependency (pyyaml)...\n'));
-            try { execSync('pip3 install pyyaml -q', { stdio: 'ignore', timeout: 30000 }); } catch {}
+            let installed = false;
+            try {
+                execSync('pip3 install pyyaml -q', { stdio: 'ignore', timeout: 30000 });
+                execSync('python3 -c "import yaml"', { stdio: 'ignore', timeout: 5000 });
+                installed = true;
+            } catch {}
+            if (!installed) {
+                console.log(chalk.gray('  pyyaml could not be installed (pip refused or failed). Using the built-in YAML reader for scan, check and lint instead.\n'));
+            }
         }
+        // Spec health via the shared engine: works with or without PyYAML.
+        const scoreSpec = (specPath) => apiEngine.specHealth(specPath);
 
         // Detect if target is a spec file or a project directory
         const isFile = fs.existsSync(target) && fs.statSync(target).isFile();
@@ -2758,11 +2771,7 @@ program
             // Spec file — run spec health + show results
             console.log(chalk.gray(`  Analyzing ${target}...\n`));
             try {
-                const result = execSync(
-                    `python3 -c "import sys,json; sys.path.insert(0,'${serverDir}'); from core.spec_health import score_spec; import yaml; spec=yaml.safe_load(open('${target}')); r=score_spec(spec); print(json.dumps(r))"`,
-                    { encoding: 'utf-8', timeout: 15000, cwd: serverDir }
-                );
-                const health = JSON.parse(result);
+                const health = scoreSpec(target);
                 const gradeColors = { A: 'green', B: 'blue', C: 'yellow', D: 'red', F: 'red' };
                 const gradeColor = gradeColors[health.grade] || 'white';
                 console.log(`  ${chalk[gradeColor].bold(health.grade)} ${chalk.white.bold(health.overall_score + '/100')}  ${chalk.gray('Spec Health Score')}\n`);
@@ -2840,11 +2849,7 @@ program
                     const specFile = path.join(target, found[0]);
                     console.log(chalk.gray(`\n  Scoring ${found[0]}...\n`));
                     try {
-                        const healthResult = execSync(
-                            `python3 -c "import sys,json; sys.path.insert(0,'${serverDir}'); from core.spec_health import score_spec; import yaml; spec=yaml.safe_load(open('${specFile}')); r=score_spec(spec); print(json.dumps(r))"`,
-                            { encoding: 'utf-8', timeout: 15000, cwd: serverDir }
-                        );
-                        const health = JSON.parse(healthResult);
+                        const health = scoreSpec(specFile);
                         const gradeColors = { A: 'green', B: 'blue', C: 'yellow', D: 'red', F: 'red' };
                         const gradeColor = gradeColors[health.grade] || 'white';
                         console.log(`  ${chalk[gradeColor].bold(health.grade)} ${chalk.white.bold(health.overall_score + '/100')}  ${chalk.gray('Spec Health Score')}\n`);
@@ -2861,7 +2866,9 @@ program
                                 console.log(`  ${chalk.yellow('\u2192')} ${text}`);
                             });
                         }
-                    } catch {}
+                    } catch (e) {
+                        console.log(chalk.yellow(`  Scoring skipped: ${String((e && e.message) || e).split('\n')[0]}`));
+                    }
                 } else {
                     console.log(`  ${chalk.yellow('\u2014')} No OpenAPI specs found in this directory`);
                     console.log('');
@@ -2870,11 +2877,7 @@ program
                     if (fs.existsSync(demoSpec)) {
                         console.log(chalk.gray('  Running demo on a sample Pet Store API...\n'));
                         try {
-                            const demoResult = execSync(
-                                `python3 -c "import sys,json; sys.path.insert(0,'${serverDir}'); from core.spec_health import score_spec; import yaml; spec=yaml.safe_load(open('${demoSpec}')); r=score_spec(spec); print(json.dumps(r))"`,
-                                { encoding: 'utf-8', timeout: 15000, cwd: serverDir }
-                            );
-                            const health = JSON.parse(demoResult);
+                            const health = scoreSpec(demoSpec);
                             const gradeColors = { A: 'green', B: 'blue', C: 'yellow', D: 'red', F: 'red' };
                             const gradeColor = gradeColors[health.grade] || 'white';
                             console.log(`  ${chalk[gradeColor].bold(health.grade)} ${chalk.white.bold(health.overall_score + '/100')}  ${chalk.gray('Sample: Pet Store API')}\n`);
@@ -2887,7 +2890,9 @@ program
                             console.log('');
                             console.log(chalk.gray('  This is a demo. Point at your spec: npx delimit-cli scan openapi.yaml'));
                             console.log('');
-                        } catch {}
+                        } catch (e) {
+                            console.log(chalk.yellow(`  Demo scoring skipped: ${String((e && e.message) || e).split('\n')[0]}`));
+                        }
                     } else {
                         console.log(chalk.gray('  Tip: point at a spec file: npx delimit-cli scan openapi.yaml'));
                     }
@@ -4956,6 +4961,17 @@ program
         let totalWarnings = 0;
         let totalViolations = [];
         let allPassed = true;
+        // Fail closed (LED-4423): a spec the engine could not analyse is a
+        // gate failure, never a pass. Counted separately from breaking changes
+        // so the summary says what actually happened.
+        let totalUnanalysed = 0;
+        const failClosed = (specFile, reason) => {
+            allPassed = false;
+            totalUnanalysed += 1;
+            const firstLine = String(reason || 'unknown error').split('\n').map(s => s.trim()).filter(Boolean)[0] || 'unknown error';
+            totalViolations.push({ rule: 'analysis_failed', severity: 'error', message: `${specFile}: could not analyse: ${firstLine}`, path: specFile });
+            console.log(`  ${chalk.red('X')} ${specFile} ${chalk.red(`- could not analyse: ${firstLine}`)}`);
+        };
 
         for (const specFile of specFiles) {
             const fullPath = path.join(projectDir, specFile);
@@ -5011,10 +5027,11 @@ program
                         console.log(`    ${chalk.gray('Semver:')} ${bumpColor(bump)}`);
                     }
                 } else {
-                    console.log(`  ${chalk.green('+')} ${specFile} ${chalk.green('— clean')}`);
+                    const detail = (result && (result.error || result.message)) || 'engine returned no summary';
+                    failClosed(specFile, detail);
                 }
             } catch (err) {
-                console.log(`  ${chalk.green('+')} ${specFile} ${chalk.green('— clean')}`);
+                failClosed(specFile, (err && err.message) || err);
             } finally {
                 try { fs.unlinkSync(tmpBase); } catch {}
             }
@@ -5059,10 +5076,11 @@ program
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
         const secretCount = secretFindings.length;
         console.log('');
-        if (totalBreaking > 0 || secretCount > 0) {
+        if (totalBreaking > 0 || secretCount > 0 || totalUnanalysed > 0) {
             const parts = [];
             if (totalBreaking > 0) parts.push(`${totalBreaking} breaking change(s)`);
             if (secretCount > 0) parts.push(`${secretCount} leaked secret(s)`);
+            if (totalUnanalysed > 0) parts.push(`${totalUnanalysed} spec(s) could not be analysed`);
             console.log(chalk.red.bold(`  BLOCKED — ${parts.join(' + ')}`));
             if (totalBreaking > 0 && !opts.fix) {
                 console.log(chalk.gray('  Run with --fix to see migration guidance'));
@@ -5098,10 +5116,11 @@ program
                     head: headSha,
                     zero_config: zeroConfig,
                     policy_preset: preset,
-                    verdict: (totalBreaking > 0 || secretCount > 0) ? 'blocked' : 'passed',
+                    verdict: (totalBreaking > 0 || secretCount > 0 || totalUnanalysed > 0) ? 'blocked' : 'passed',
                     findings: {
                         breaking_changes: totalBreaking,
                         warnings: totalWarnings,
+                        unanalysed_specs: totalUnanalysed,
                         leaked_secrets: secretFindings.map(s => ({ file: s.file, label: s.label })),
                         spec_violations: (totalViolations || []).map(v => ({ message: v.message, severity: v.severity, path: v.path })),
                     },

--- a/lib/api-engine.js
+++ b/lib/api-engine.js
@@ -77,6 +77,10 @@ function runGateway(pythonCode, timeoutMs = 30000) {
                 cwd: GATEWAY_ROOT,
                 timeout: timeoutMs,
                 encoding: 'utf-8',
+                // Capture stderr instead of echoing it: a raw Python
+                // Traceback must never reach the user's terminal on its own.
+                // It is surfaced through the thrown Error below.
+                stdio: ['ignore', 'pipe', 'pipe'],
                 env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
             }
         );
@@ -97,7 +101,15 @@ function runGateway(pythonCode, timeoutMs = 30000) {
                 `Python not found. Install Python 3.9+ and try again.\n\nDetails: ${err.message}`
             );
         }
-        throw new Error(err.stderr || err.message || 'Gateway execution failed');
+        // Lead with the actual exception line (the LAST non-empty stderr
+        // line) so callers that show only the first line say something
+        // useful instead of "Traceback (most recent call last):".
+        if (stderr.trim()) {
+            const lines = stderr.trim().split('\n').map(s => s.trim()).filter(Boolean);
+            const headline = lines[lines.length - 1];
+            throw new Error(`${headline}\n\n${stderr.trim()}`);
+        }
+        throw new Error(err.message || 'Gateway execution failed');
     } finally {
         try { fs.unlinkSync(tmpFile); } catch (_) {}
     }
@@ -111,44 +123,204 @@ function pyStr(s) {
     return JSON.stringify(s);  // JSON strings are valid Python strings
 }
 
+// ---------------------------------------------------------------------------
+// Zero-config YAML (LED-4423).
+//
+// `delimit check` is advertised as zero-config: no `setup`, no venv. On a
+// fresh Debian 12 host the system python3 has no `yaml` module and
+// `pip install pyyaml` is refused (PEP 668). Every helper below used to start
+// with `import json, yaml, sys`, so the gate could not even parse the spec.
+//
+// Strategy: probe ONCE whether the chosen python can `import yaml`. If it
+// cannot, parse each YAML input in node with the bundled `js-yaml` and hand
+// the helper a temp JSON file instead (JSON is valid YAML, so the same path
+// also works when PyYAML IS present). The helper header installs a tiny
+// JSON-backed `yaml` shim into sys.modules when PyYAML is missing, because
+// the bundled gateway core (policy_engine.py) imports `yaml` at module level.
+// ---------------------------------------------------------------------------
+
+let _pyYamlAvailable = null;
+
+/**
+ * True when the selected python interpreter can `import yaml`. Cached.
+ */
+function pythonHasYaml() {
+    if (_pyYamlAvailable !== null) return _pyYamlAvailable;
+    try {
+        execSync(`${PYTHON} -c "import yaml"`, {
+            stdio: 'pipe',
+            timeout: 10000,
+            env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
+        });
+        _pyYamlAvailable = true;
+    } catch {
+        _pyYamlAvailable = false;
+    }
+    return _pyYamlAvailable;
+}
+
+/**
+ * Parse a YAML/JSON spec in node and write it out as a temp JSON file.
+ * Returns the temp path. Throws with a clear message on parse failure.
+ */
+function yamlToTempJson(specPath) {
+    const jsYaml = require('js-yaml');
+    const raw = fs.readFileSync(specPath, 'utf-8');
+    let doc;
+    try {
+        doc = jsYaml.load(raw);
+    } catch (e) {
+        throw new Error(`Could not parse ${specPath} as YAML: ${e.message}`);
+    }
+    const tmp = path.join(
+        os.tmpdir(),
+        `delimit_spec_${process.pid}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.json`
+    );
+    fs.writeFileSync(tmp, JSON.stringify(doc === undefined ? null : doc));
+    return tmp;
+}
+
+/**
+ * Prepare spec inputs for the python helper. When PyYAML is missing the
+ * YAML files are converted to temp JSON files; otherwise the originals are
+ * passed through untouched. Always call `cleanup()` in a finally block.
+ *
+ * @param {string[]} paths
+ * @returns {{ paths: string[], cleanup: () => void }}
+ */
+function prepareSpecInputs(paths) {
+    if (pythonHasYaml()) {
+        return { paths: paths.slice(), cleanup: () => {} };
+    }
+    const temps = [];
+    const out = [];
+    try {
+        for (const p of paths) {
+            if (p == null) { out.push(p); continue; }
+            const t = yamlToTempJson(p);
+            temps.push(t);
+            out.push(t);
+        }
+    } catch (e) {
+        for (const t of temps) { try { fs.unlinkSync(t); } catch (_) {} }
+        throw e;
+    }
+    return {
+        paths: out,
+        cleanup: () => { for (const t of temps) { try { fs.unlinkSync(t); } catch (_) {} } },
+    };
+}
+
+/**
+ * Guarded helper header: `yaml` is optional. When PyYAML is missing a
+ * JSON-backed shim is installed into sys.modules so the gateway core's own
+ * `import yaml` succeeds, and `_load(path)` reads the (JSON) spec.
+ */
+// The shim first tries JSON (the pre-converted spec inputs). Anything else
+// (e.g. the gateway's own policy presets under core/policies/*.yml) is
+// parsed by handing the text to node + js-yaml, which is always present
+// because this helper only ever runs underneath the node CLI.
+function _jsYamlPath() {
+    try { return require.resolve('js-yaml'); } catch { return null; }
+}
+const _NODE_YAML_TO_JSON = [
+    'const fs=require("fs");',
+    'const y=require(process.argv[1]);',
+    'let s="";',
+    'try{s=fs.readFileSync(0,"utf8")}catch(e){}',
+    'const d=y.load(s);',
+    'process.stdout.write(JSON.stringify(d===undefined?null:d));',
+].join('');
+
+const PY_HEADER = [
+    'import json, sys',
+    'try:',
+    '    import yaml',
+    'except ImportError:',
+    '    yaml = None',
+    'if yaml is None:',
+    '    import types as _types, subprocess as _sp',
+    `    _NODE = ${pyStr(process.execPath)}`,
+    `    _JSYAML = ${pyStr(_jsYamlPath())}`,
+    `    _NODE_SCRIPT = ${pyStr(_NODE_YAML_TO_JSON)}`,
+    '    def _delimit_yaml_via_node(data):',
+    '        if not _JSYAML:',
+    '            raise RuntimeError("PyYAML is not installed and the built-in YAML reader (js-yaml) is unavailable.")',
+    '        p = _sp.run([_NODE, "-e", _NODE_SCRIPT, _JSYAML], input=data.encode("utf-8"), stdout=_sp.PIPE, stderr=_sp.PIPE)',
+    '        if p.returncode != 0:',
+    '            err = p.stderr.decode("utf-8", "replace").strip().splitlines()',
+    '            raise RuntimeError("YAML parse failed: " + (err[-1] if err else "unknown error"))',
+    '        return json.loads(p.stdout.decode("utf-8"))',
+    '    def _delimit_json_safe_load(stream):',
+    '        data = stream if isinstance(stream, (str, bytes)) else stream.read()',
+    '        if isinstance(data, bytes): data = data.decode("utf-8")',
+    '        if not data.strip(): return None',
+    '        try:',
+    '            return json.loads(data)',
+    '        except ValueError:',
+    '            return _delimit_yaml_via_node(data)',
+    '    yaml = _types.ModuleType("yaml")',
+    '    yaml.safe_load = _delimit_json_safe_load',
+    '    yaml.load = lambda stream, *a, **k: _delimit_json_safe_load(stream)',
+    '    yaml.safe_dump = lambda data, *a, **k: json.dumps(data, indent=2)',
+    '    yaml.dump = yaml.safe_dump',
+    '    yaml.YAMLError = ValueError',
+    '    yaml.__delimit_shim__ = True',
+    '    sys.modules["yaml"] = yaml',
+    'def _load(p):',
+    '    with open(p, "r", encoding="utf-8") as f: return yaml.safe_load(f)',
+    'sys.path.insert(0, ".")',
+];
+
 /**
  * delimit lint — diff + policy evaluation (primary command)
  */
 function lint(oldSpec, newSpec, opts = {}) {
-    const lines = [
-        'import json, yaml, sys',
-        'sys.path.insert(0, ".")',
-        'from core.policy_engine import evaluate_with_policy',
-        `with open(${pyStr(oldSpec)}) as f: old = yaml.safe_load(f)`,
-        `with open(${pyStr(newSpec)}) as f: new = yaml.safe_load(f)`,
-        `r = evaluate_with_policy(old, new`,
-    ];
-    const args = ['include_semver=True'];
-    if (opts.policy) args.push(`policy_file=${pyStr(opts.policy)}`);
-    if (opts.version) args.push(`current_version=${pyStr(opts.version)}`);
-    if (opts.name) args.push(`api_name=${pyStr(opts.name)}`);
-    // Close the function call
-    lines[lines.length - 1] = `r = evaluate_with_policy(old, new, ${args.join(', ')})`;
-    lines.push('print(json.dumps(r))');
-    return runGateway(lines.join('\n'));
+    // A policy file (a real path, not a preset name) is YAML too: convert it
+    // alongside the specs so the no-PyYAML path can still load custom rules.
+    const policyIsFile = !!(opts.policy && fs.existsSync(opts.policy) && fs.statSync(opts.policy).isFile());
+    const inputs = prepareSpecInputs(policyIsFile ? [oldSpec, newSpec, opts.policy] : [oldSpec, newSpec]);
+    try {
+        const [oldPath, newPath, policyPath] = inputs.paths;
+        const lines = [
+            ...PY_HEADER,
+            'from core.policy_engine import evaluate_with_policy',
+            `old = _load(${pyStr(oldPath)})`,
+            `new = _load(${pyStr(newPath)})`,
+        ];
+        const args = ['include_semver=True'];
+        if (opts.policy) args.push(`policy_file=${pyStr(policyIsFile ? policyPath : opts.policy)}`);
+        if (opts.version) args.push(`current_version=${pyStr(opts.version)}`);
+        if (opts.name) args.push(`api_name=${pyStr(opts.name)}`);
+        lines.push(`r = evaluate_with_policy(old, new, ${args.join(', ')})`);
+        lines.push('print(json.dumps(r))');
+        return runGateway(lines.join('\n'));
+    } finally {
+        inputs.cleanup();
+    }
 }
 
 /**
  * delimit diff — pure diff, no policy
  */
 function diff(oldSpec, newSpec) {
-    return runGateway([
-        'import json, yaml, sys',
-        'sys.path.insert(0, ".")',
-        'from core.diff_engine_v2 import OpenAPIDiffEngine',
-        `with open(${pyStr(oldSpec)}) as f: old = yaml.safe_load(f)`,
-        `with open(${pyStr(newSpec)}) as f: new = yaml.safe_load(f)`,
-        'engine = OpenAPIDiffEngine()',
-        'changes = engine.compare(old, new)',
-        'breaking = [c for c in changes if c.is_breaking]',
-        'r = {"total_changes": len(changes), "breaking_changes": len(breaking), "changes": [{"type": c.type.value, "path": c.path, "message": c.message, "is_breaking": c.is_breaking} for c in changes]}',
-        'print(json.dumps(r))',
-    ].join('\n'));
+    const inputs = prepareSpecInputs([oldSpec, newSpec]);
+    try {
+        const [oldPath, newPath] = inputs.paths;
+        return runGateway([
+            ...PY_HEADER,
+            'from core.diff_engine_v2 import OpenAPIDiffEngine',
+            `old = _load(${pyStr(oldPath)})`,
+            `new = _load(${pyStr(newPath)})`,
+            'engine = OpenAPIDiffEngine()',
+            'changes = engine.compare(old, new)',
+            'breaking = [c for c in changes if c.is_breaking]',
+            'r = {"total_changes": len(changes), "breaking_changes": len(breaking), "changes": [{"type": c.type.value, "path": c.path, "message": c.message, "is_breaking": c.is_breaking} for c in changes]}',
+            'print(json.dumps(r))',
+        ].join('\n'));
+    } finally {
+        inputs.cleanup();
+    }
 }
 
 /**
@@ -161,18 +333,23 @@ function explain(oldSpec, newSpec, opts = {}) {
     if (opts.newVersion) args.push(`new_version=${pyStr(opts.newVersion)}`);
     if (opts.name) args.push(`api_name=${pyStr(opts.name)}`);
 
-    return runGateway([
-        'import json, yaml, sys',
-        'sys.path.insert(0, ".")',
-        'from core.diff_engine_v2 import OpenAPIDiffEngine',
-        'from core.explainer import explain, TEMPLATES',
-        `with open(${pyStr(oldSpec)}) as f: old = yaml.safe_load(f)`,
-        `with open(${pyStr(newSpec)}) as f: new = yaml.safe_load(f)`,
-        'engine = OpenAPIDiffEngine()',
-        'changes = engine.compare(old, new)',
-        `out = explain(changes, ${args.join(', ')})`,
-        `print(json.dumps({"template": ${pyStr(template)}, "available_templates": TEMPLATES, "output": out}))`,
-    ].join('\n'));
+    const inputs = prepareSpecInputs([oldSpec, newSpec]);
+    try {
+        const [oldPath, newPath] = inputs.paths;
+        return runGateway([
+            ...PY_HEADER,
+            'from core.diff_engine_v2 import OpenAPIDiffEngine',
+            'from core.explainer import explain, TEMPLATES',
+            `old = _load(${pyStr(oldPath)})`,
+            `new = _load(${pyStr(newPath)})`,
+            'engine = OpenAPIDiffEngine()',
+            'changes = engine.compare(old, new)',
+            `out = explain(changes, ${args.join(', ')})`,
+            `print(json.dumps({"template": ${pyStr(template)}, "available_templates": TEMPLATES, "output": out}))`,
+        ].join('\n'));
+    } finally {
+        inputs.cleanup();
+    }
 }
 
 /**
@@ -186,19 +363,24 @@ function semver(oldSpec, newSpec, currentVersion) {
           ]
         : [];
 
-    return runGateway([
-        'import json, yaml, sys',
-        'sys.path.insert(0, ".")',
-        'from core.diff_engine_v2 import OpenAPIDiffEngine',
-        'from core.semver_classifier import classify_detailed, bump_version, classify',
-        `with open(${pyStr(oldSpec)}) as f: old = yaml.safe_load(f)`,
-        `with open(${pyStr(newSpec)}) as f: new = yaml.safe_load(f)`,
-        'engine = OpenAPIDiffEngine()',
-        'changes = engine.compare(old, new)',
-        'r = classify_detailed(changes)',
-        ...extraLines,
-        'print(json.dumps(r))',
-    ].join('\n'));
+    const inputs = prepareSpecInputs([oldSpec, newSpec]);
+    try {
+        const [oldPath, newPath] = inputs.paths;
+        return runGateway([
+            ...PY_HEADER,
+            'from core.diff_engine_v2 import OpenAPIDiffEngine',
+            'from core.semver_classifier import classify_detailed, bump_version, classify',
+            `old = _load(${pyStr(oldPath)})`,
+            `new = _load(${pyStr(newPath)})`,
+            'engine = OpenAPIDiffEngine()',
+            'changes = engine.compare(old, new)',
+            'r = classify_detailed(changes)',
+            ...extraLines,
+            'print(json.dumps(r))',
+        ].join('\n'));
+    } finally {
+        inputs.cleanup();
+    }
 }
 
 /**
@@ -239,4 +421,23 @@ function zeroSpec(projectDir, opts = {}) {
     ].join('\n'));
 }
 
-module.exports = { lint, diff, explain, semver, zeroSpec, GATEWAY_ROOT };
+/**
+ * Spec health score (used by `delimit scan`). Same zero-config YAML path as
+ * the other helpers: works with or without PyYAML.
+ */
+function specHealth(specPath) {
+    const inputs = prepareSpecInputs([specPath]);
+    try {
+        const [p] = inputs.paths;
+        return runGateway([
+            ...PY_HEADER,
+            'from core.spec_health import score_spec',
+            `spec = _load(${pyStr(p)})`,
+            'print(json.dumps(score_spec(spec)))',
+        ].join('\n'));
+    } finally {
+        inputs.cleanup();
+    }
+}
+
+module.exports = { lint, diff, explain, semver, zeroSpec, specHealth, pythonHasYaml, GATEWAY_ROOT, PYTHON };

--- a/scripts/test-with-config-guard.js
+++ b/scripts/test-with-config-guard.js
@@ -47,6 +47,7 @@ const TEST_FILES = [
     'tests/chat-repl-continuity.test.js',
     'tests/cli-deliberate-runs-engine.test.js',
     'tests/funnel-cli-leaks.test.js',
+    'tests/check-fail-closed-no-pyyaml.test.js',
 ];
 
 const cfgPath = resolveSharedConfigPath();

--- a/tests/check-fail-closed-no-pyyaml.test.js
+++ b/tests/check-fail-closed-no-pyyaml.test.js
@@ -1,0 +1,322 @@
+/**
+ * LED-4423 (P0): `delimit check` must FAIL CLOSED, and the engine must work
+ * on a python with no PyYAML (zero-config, no `setup`).
+ *
+ * Origin: a fresh Debian 12 container (system python3 without `yaml`,
+ * `pip install pyyaml` refused under PEP 668) ran `delimit check` on a spec
+ * with a REMOVED ENDPOINT. The helper died with ModuleNotFoundError, the
+ * CLI swallowed the error, printed "+ openapi.yaml — clean" and PASSED.
+ *
+ * Covered here:
+ *   (a) any helper error, or a result without `summary`, is reported as
+ *       "could not analyse", counted as a violation, exit code 1, and the
+ *       word "clean" never appears;
+ *   (b) with a python that cannot `import yaml`, `check` on a removed
+ *       endpoint reports BLOCKED / MAJOR with exit 1 and no Traceback;
+ *   (c) `diff` / `lint` / `explain` on that same python still produce the
+ *       breaking-change output;
+ *   (d) `scan` on that python (with pip refusing) prints one clear line and
+ *       still scores the spec; no Traceback;
+ *   (e) temp JSON conversions are cleaned up.
+ *
+ * How the no-yaml python is simulated: a `python3` shim placed FIRST on PATH
+ * execs the real interpreter with `-S` (no site-packages: PyYAML lives in
+ * site/dist-packages, the stdlib does not). The shim is verified before use:
+ * `import yaml` must fail and `import json` must succeed. HOME/DELIMIT_HOME
+ * point at an empty tmp dir so no ~/.delimit/venv can be preferred.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+const { makeTmpGitRepo } = require('./_git-hermetic');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const CLI = path.join(REPO_ROOT, 'bin', 'delimit-cli.js');
+const API_ENGINE = path.join(REPO_ROOT, 'lib', 'api-engine.js');
+const PETSTORE_V1 = path.join(REPO_ROOT, 'examples', 'petstore-v1.yaml');
+const PETSTORE_V2 = path.join(REPO_ROOT, 'examples', 'petstore-v2.yaml');
+
+function realPython() {
+    try {
+        return execSync('command -v python3', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Build a bin dir whose `python3` runs the real interpreter with -S
+ * (no site-packages => no PyYAML) and whose `pip3` refuses (PEP 668).
+ */
+function makeNoYamlPythonDir(real) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-noyaml-py-'));
+    fs.writeFileSync(path.join(dir, 'python3'), `#!/bin/sh\nexec "${real}" -S "$@"\n`, { mode: 0o755 });
+    fs.writeFileSync(path.join(dir, 'python'), `#!/bin/sh\nexec "${real}" -S "$@"\n`, { mode: 0o755 });
+    const refuse = '#!/bin/sh\necho "error: externally-managed-environment" >&2\nexit 1\n';
+    fs.writeFileSync(path.join(dir, 'pip3'), refuse, { mode: 0o755 });
+    fs.writeFileSync(path.join(dir, 'pip'), refuse, { mode: 0o755 });
+    return dir;
+}
+
+/** A python3 that always fails (simulates any helper crash). */
+function makeBrokenPythonDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-broken-py-'));
+    fs.writeFileSync(path.join(dir, 'python3'), '#!/bin/sh\necho "boom: helper exploded" >&2\nexit 1\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(dir, 'python'), '#!/bin/sh\necho "boom: helper exploded" >&2\nexit 1\n', { mode: 0o755 });
+    return dir;
+}
+
+/** Hermetic env for spawning the CLI: shim bin first on PATH, empty HOME. */
+function cliEnv(baseEnv, binDir, home) {
+    const env = { ...baseEnv };
+    env.PATH = `${binDir}${path.delimiter}${baseEnv.PATH || process.env.PATH}`;
+    env.HOME = home;
+    env.DELIMIT_HOME = path.join(home, '.delimit');
+    env.FORCE_COLOR = '0';
+    env.NO_COLOR = '1';
+    env.CI = '1';
+    delete env.DELIMIT_GATEWAY_ROOT;
+    delete env.NODE_OPTIONS;
+    return env;
+}
+
+function runCli(args, { cwd, env }) {
+    const r = spawnSync(process.execPath, [CLI, ...args], {
+        cwd,
+        env,
+        encoding: 'utf-8',
+        timeout: 60000,
+        input: '',
+    });
+    return { status: r.status, out: `${r.stdout || ''}\n${r.stderr || ''}` };
+}
+
+/** Temp repo: api/openapi.yaml committed as petstore v1, working tree = v2 (removed endpoint). */
+function makeRemovedEndpointRepo() {
+    const repo = makeTmpGitRepo({ prefix: 'delimit-check-fc-', commit: true });
+    fs.mkdirSync(path.join(repo.dir, 'api'), { recursive: true });
+    fs.copyFileSync(PETSTORE_V1, path.join(repo.dir, 'api', 'openapi.yaml'));
+    repo.run('git add api/openapi.yaml');
+    repo.run('git commit -qm "petstore v1"');
+    fs.copyFileSync(PETSTORE_V2, path.join(repo.dir, 'api', 'openapi.yaml'));
+    return repo;
+}
+
+function countSpecTemps() {
+    return fs.readdirSync(os.tmpdir()).filter(f => f.startsWith('delimit_spec_')).length;
+}
+
+const PY = realPython();
+
+describe('LED-4423: no-PyYAML python shim is real', { skip: PY ? false : 'python3 not on PATH' }, () => {
+    let binDir;
+    before(() => { binDir = makeNoYamlPythonDir(PY); });
+    after(() => { fs.rmSync(binDir, { recursive: true, force: true }); });
+
+    it('shim python3 cannot import yaml but the stdlib works', () => {
+        const env = { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH}` };
+        const yamlProbe = spawnSync('python3', ['-c', 'import yaml'], { env, encoding: 'utf-8' });
+        assert.notEqual(yamlProbe.status, 0, 'shim must NOT be able to import yaml (is PyYAML vendored into the stdlib here?)');
+        assert.match(yamlProbe.stderr, /No module named 'yaml'/);
+        const jsonProbe = spawnSync('python3', ['-c', 'import json, sys; print(json.dumps({"ok": True}))'], { env, encoding: 'utf-8' });
+        assert.equal(jsonProbe.status, 0, `stdlib must work under the shim: ${jsonProbe.stderr}`);
+        assert.equal(jsonProbe.stdout.trim(), '{"ok": true}');
+    });
+
+    it('api-engine.pythonHasYaml() reports false under the shim', () => {
+        const savedPath = process.env.PATH;
+        const savedHome = process.env.HOME;
+        const savedDh = process.env.DELIMIT_HOME;
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-noyaml-home-'));
+        try {
+            process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+            process.env.HOME = home;
+            process.env.DELIMIT_HOME = path.join(home, '.delimit');
+            delete require.cache[require.resolve(API_ENGINE)];
+            const engine = require(API_ENGINE);
+            assert.equal(engine.pythonHasYaml(), false);
+            // And the engine still diffs the specs (node-side YAML -> JSON).
+            const r = engine.diff(PETSTORE_V1, PETSTORE_V2);
+            assert.ok(r.breaking_changes >= 1, `expected breaking changes, got ${JSON.stringify(r).slice(0, 200)}`);
+            assert.ok(r.changes.some(c => /removed/i.test(c.message) && /vaccinations/.test(c.message)));
+        } finally {
+            process.env.PATH = savedPath;
+            process.env.HOME = savedHome;
+            if (savedDh === undefined) delete process.env.DELIMIT_HOME; else process.env.DELIMIT_HOME = savedDh;
+            delete require.cache[require.resolve(API_ENGINE)];
+            fs.rmSync(home, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('LED-4423 (a): delimit check fails CLOSED on helper errors', () => {
+    let repo, brokenDir, home;
+    before(() => {
+        repo = makeRemovedEndpointRepo();
+        brokenDir = makeBrokenPythonDir();
+        home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-fc-home-'));
+    });
+    after(() => {
+        repo.cleanup();
+        fs.rmSync(brokenDir, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    });
+
+    it('python that always exits 1: "could not analyse", exit 1, never "clean"', () => {
+        const env = cliEnv(repo.env, brokenDir, home);
+        const { status, out } = runCli(['check'], { cwd: repo.dir, env });
+        assert.equal(status, 1, `expected exit 1\n${out}`);
+        assert.match(out, /could not analyse/);
+        assert.match(out, /boom: helper exploded/);
+        assert.match(out, /BLOCKED/);
+        assert.match(out, /could not be analysed/);
+        assert.doesNotMatch(out, /clean/);
+        assert.doesNotMatch(out, /PASSED/);
+    });
+
+    it('--staged keeps the same fail-closed behaviour', () => {
+        repo.run('git add api/openapi.yaml');
+        const env = cliEnv(repo.env, brokenDir, home);
+        const { status, out } = runCli(['check', '--staged'], { cwd: repo.dir, env });
+        repo.run('git reset -q api/openapi.yaml');
+        assert.equal(status, 1, out);
+        assert.match(out, /could not analyse/);
+        assert.doesNotMatch(out, /clean/);
+    });
+
+    it('stubbed api-engine that throws => could not analyse, exit 1', () => {
+        const preload = path.join(home, 'stub-throw.js');
+        fs.writeFileSync(preload, `
+            const Module = require('module');
+            const orig = Module._load;
+            Module._load = function (request, parent, isMain) {
+                if (/api-engine(\\.js)?$/.test(request)) {
+                    return { lint() { throw new Error('stub engine failure\\nsecond line ignored'); }, zeroSpec() { throw new Error('x'); }, GATEWAY_ROOT: '' };
+                }
+                return orig.apply(this, arguments);
+            };
+        `);
+        const env = cliEnv(repo.env, path.dirname(PY || '/usr/bin/python3'), home);
+        env.NODE_OPTIONS = `--require ${preload}`;
+        const { status, out } = runCli(['check'], { cwd: repo.dir, env });
+        assert.equal(status, 1, out);
+        assert.match(out, /could not analyse: stub engine failure/);
+        assert.doesNotMatch(out, /second line ignored/);
+        assert.doesNotMatch(out, /clean/);
+    });
+
+    it('stubbed api-engine returning a result WITHOUT summary => could not analyse, exit 1', () => {
+        const preload = path.join(home, 'stub-nosummary.js');
+        fs.writeFileSync(preload, `
+            const Module = require('module');
+            const orig = Module._load;
+            Module._load = function (request, parent, isMain) {
+                if (/api-engine(\\.js)?$/.test(request)) {
+                    return { lint() { return { error: 'engine produced no summary' }; }, zeroSpec() { throw new Error('x'); }, GATEWAY_ROOT: '' };
+                }
+                return orig.apply(this, arguments);
+            };
+        `);
+        const env = cliEnv(repo.env, path.dirname(PY || '/usr/bin/python3'), home);
+        env.NODE_OPTIONS = `--require ${preload}`;
+        const { status, out } = runCli(['check'], { cwd: repo.dir, env });
+        assert.equal(status, 1, out);
+        assert.match(out, /could not analyse: engine produced no summary/);
+        assert.doesNotMatch(out, /clean/);
+    });
+
+    it('--record verdict is "blocked" when a spec could not be analysed', () => {
+        const env = cliEnv(repo.env, brokenDir, home);
+        const recPath = path.join(repo.dir, 'rec.json');
+        const { status } = runCli(['check', '--record', recPath], { cwd: repo.dir, env });
+        assert.equal(status, 1);
+        const rec = JSON.parse(fs.readFileSync(recPath, 'utf-8'));
+        assert.equal(rec.verdict, 'blocked');
+        assert.equal(rec.findings.unanalysed_specs, 1);
+        assert.ok(rec.findings.spec_violations.some(v => /could not analyse/.test(v.message)));
+    });
+});
+
+describe('LED-4423 (b)(c)(d)(e): zero-config YAML on a python without PyYAML', { skip: PY ? false : 'python3 not on PATH' }, () => {
+    let repo, binDir, home, tempsBefore;
+    before(() => {
+        repo = makeRemovedEndpointRepo();
+        binDir = makeNoYamlPythonDir(PY);
+        home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-noyaml-home-'));
+        tempsBefore = countSpecTemps();
+    });
+    after(() => {
+        repo.cleanup();
+        fs.rmSync(binDir, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    });
+
+    it('(b) check on a removed endpoint reports BLOCKED / MAJOR, exit 1, no Traceback', () => {
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['check'], { cwd: repo.dir, env });
+        assert.equal(status, 1, `expected exit 1\n${out}`);
+        assert.match(out, /BLOCKED/);
+        assert.match(out, /Semver: MAJOR/);
+        assert.match(out, /breaking change\(s\)/);
+        assert.doesNotMatch(out, /Traceback/);
+        assert.doesNotMatch(out, /No module named/);
+        assert.doesNotMatch(out, /could not analyse/);
+        assert.doesNotMatch(out, /clean/);
+    });
+
+    it('(b) check --staged on the removed endpoint is also BLOCKED', () => {
+        repo.run('git add api/openapi.yaml');
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['check', '--staged'], { cwd: repo.dir, env });
+        repo.run('git reset -q api/openapi.yaml');
+        assert.equal(status, 1, out);
+        assert.match(out, /BLOCKED/);
+        assert.match(out, /Semver: MAJOR/);
+        assert.doesNotMatch(out, /Traceback/);
+    });
+
+    it('(c) diff shows the removed endpoint as BREAKING', () => {
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['diff', PETSTORE_V1, PETSTORE_V2], { cwd: repo.dir, env });
+        assert.equal(status, 0, out);
+        assert.match(out, /\[BREAKING\] Endpoint removed: \/pets\/\{petId\}\/vaccinations/);
+        assert.doesNotMatch(out, /Traceback/);
+    });
+
+    it('(c) lint (preset policy read from the gateway) fails with the endpoint-removal violation', () => {
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['lint', PETSTORE_V1, PETSTORE_V2, '--policy', 'strict', '--json'], { cwd: repo.dir, env });
+        assert.equal(status, 1, out);
+        const json = JSON.parse(out.slice(out.indexOf('{'), out.lastIndexOf('}') + 1));
+        assert.equal(json.decision, 'fail');
+        assert.ok(json.violations.some(v => v.rule === 'no_endpoint_removal'), JSON.stringify(json.violations));
+        assert.equal(json.semver && json.semver.bump, 'major');
+    });
+
+    it('(c) explain renders the removed endpoint', () => {
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['explain', PETSTORE_V1, PETSTORE_V2], { cwd: repo.dir, env });
+        assert.equal(status, 0, out);
+        assert.match(out, /vaccinations/);
+        assert.doesNotMatch(out, /Traceback/);
+    });
+
+    it('(d) scan on a spec file: one clear line about pyyaml, spec still scored, no Traceback', () => {
+        const env = cliEnv(repo.env, binDir, home);
+        const { status, out } = runCli(['scan', PETSTORE_V1], { cwd: repo.dir, env });
+        assert.equal(status, 0, out);
+        assert.match(out, /pyyaml could not be installed/);
+        assert.match(out, /built-in YAML reader/);
+        assert.match(out, /Spec Health Score/);
+        assert.doesNotMatch(out, /Traceback/);
+        assert.doesNotMatch(out, /No module named/);
+    });
+
+    it('(e) temp JSON conversions are cleaned up', () => {
+        assert.ok(countSpecTemps() <= tempsBefore, 'delimit_spec_* temp files left behind in os.tmpdir()');
+    });
+});


### PR DESCRIPTION
## Why (P0, LED-4423)
Fresh-user container run against main (Debian 12, empty HOME): the system Python has no `yaml` module and refuses `pip install` (PEP 668). `delimit check` on a spec with a removed endpoint printed a Python Traceback and then **"+ openapi.yaml — clean" / PASSED**. The merge gate failed open on a current stable distribution. Causes: `check`'s catch rendered any helper failure as clean (and so did the missing-summary branch); every helper script hard-required `import yaml` although `check` is zero-config with no setup; `scan` swallowed the pip refusal.

## What
- **Fail closed** (`bin/delimit-cli.js` check): any helper error or summary-less result prints `X <spec> - could not analyse: <reason>`, records an `analysis_failed` violation, sets the run BLOCKED, exits 1; `--record` verdict is `blocked` with `findings.unanalysed_specs`. Unborn-HEAD and `--staged` paths from #199/#201 untouched.
- **Zero-config YAML** (`lib/api-engine.js`): `pythonHasYaml()` probe (cached); when PyYAML is missing, spec/policy inputs are parsed in Node with the bundled `js-yaml` and passed as temp JSON; the helper header installs a JSON-backed `yaml` shim into `sys.modules` (the bundled gateway core imports `yaml` at module level and its policy presets are real YAML, so non-JSON text is delegated to Node + js-yaml). Applied to lint, diff, explain, semver; new `specHealth()`. `runGateway` captures stderr so raw Tracebacks never reach the terminal; thrown errors lead with the real exception line.
- **scan**: pip refusal prints one line ("pyyaml could not be installed … Using the built-in YAML reader …") and scoring uses the same engine; "Scoring skipped: <reason>" instead of silence.
- **Tests**: `tests/check-fail-closed-no-pyyaml.test.js` (14, registered, run on CI): broken python → "could not analyse", exit 1, never clean (also `--staged`, stub engine throwing, missing summary, `--record` blocked); a no-yaml python shim (`exec real python -S`, pip shims that print externally-managed-environment; asserted that `import yaml` fails and `import json` works) → `check` on a removed endpoint reports BLOCKED / MAJOR / exit 1 with no Traceback, also `--staged`; diff/lint/explain via the same shim produce the breaking-change output; scan prints the notice and a health score; no temp files left.

## Verification (orchestrator, independent of the agent)
- `npm test`: 382 pass, 0 fail. `gateway/` untouched.
- **Container acceptance**: the fresh-user harness re-run in `node:20-bookworm-slim` (empty HOME, no venv, system python without yaml) against a tarball packed from this head: `scan` prints the one-line notice and scores the spec; `check` on the untouched spec → clean; `check` on the spec with a removed endpoint → **X openapi.yaml — 1 breaking / Semver: MAJOR / BLOCKED, exit 1**; `lint` → GOVERNANCE FAILED; zero "No module named" anywhere. The only Traceback left in the run is the compiled engine's glibc ImportError (LED-4424, separate).

Consequence tier: HIGH (the merge gate's verdict on customer machines). Must precede 4.18.3.

Head: 07036c48d57a3a7d1c369d55213dab062b87a563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
