### PR TITLE
chore(pro): proModuleVersion 3.10.1 (engine rebuilt for glibc 2.34, LED-4424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Pro engine modules now resolve to v3.10.1, rebuilt on Ubuntu 22.04 so the compiled deliberation, governance and license modules load on Debian 12 and Ubuntu 22.04 (v3.10.0 required glibc 2.38 and failed to import there, which left hosted deliberation dead and license gating on the Python fallback). Existing installs pick the new engine up on their next `delimit setup`.
+
 ## [4.18.3] - 2026-09-04
 
 The fresh-user release: every change here was found by installing Delimit as a stranger would, in an empty Debian 12 container, and reading back what a first-time user actually sees. One of those findings was severe.

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "js-yaml": "^4.1.0",
     "minimatch": "^5.1.0"
   },
-  "proModuleVersion": "3.10.0",
+  "proModuleVersion": "3.10.1",
   "engines": {
     "node": ">=14.0.0"
   }


### PR DESCRIPTION
## Summary
Head: 587b179b5c2ecb661f1a9d2b8d9fc8be9c84f949
Base: 795ac5504bb02836443d7c89d269a17231b09371

Consequence class: C2 for this metadata change; it becomes C3 when shipped by the next npm release, which stays founder-gated. Return class: customer (correctness of the paid engine on Debian 12 / Ubuntu 22.04).

Bumps `proModuleVersion` 3.10.0 -> 3.10.1 and adds the CHANGELOG Unreleased note. The v3.10.1 engine tarballs are already published and verified: all six read back from https://delimit.ai/releases/v3.10.1/ with sha256 identical to the committed artifacts (delimit-ui 9fc8ead), built by gateway pro-release.yml run 33937041771 on ubuntu-22.04 (Linux modules bound to glibc 2.34; Debian 12 smoke import passed for cp310/311/312; zero bypass identifiers). LED-4424.

No code path changes: `bin/delimit-setup.js` reads `pkg.proModuleVersion` to build the download URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
