### PR TITLE
sync(gateway): server.py from e5b802a — self-locating import path, no PYTHONPATH needed (LED-4415)

### DIFF
--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -53,6 +53,25 @@ import traceback
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────
+#  Self-locating import path (2026-09-05, LED-4415)
+#
+#  Launchers that start this file directly (`python gateway/ai/server.py`,
+#  Docker ENTRYPOINTs, MCP directories building their own image) must be
+#  able to resolve the `ai` package WITHOUT a PYTHONPATH. Glama's hosted
+#  builds stopped applying PYTHONPATH and every release build after
+#  2026-09-03 died on the first `from ai...` import with
+#  "No module named 'ai'". The gateway root (parent of `ai/`) and `ai/`
+#  itself go on sys.path, in that order, matching the PYTHONPATH the
+#  Dockerfile sets; a launcher that does set PYTHONPATH sees no change.
+# ─────────────────────────────────────────────────────────────────────
+import sys as _sys
+_SERVER_FILE = Path(__file__).resolve()
+for _p in (str(_SERVER_FILE.parent), str(_SERVER_FILE.parent.parent)):
+    if _p not in _sys.path:
+        _sys.path.insert(0, _p)
+del _p
 from typing import Annotated, Any, Dict, List, Optional, Union
 
 from fastmcp import FastMCP


### PR DESCRIPTION
## Summary
Head: ee0a1789904a763caa3fd79cfa2a391687f8d45d
Base: 530c82246212eb040917897760d44cfd3fc88b2d

Sync-only carry of gateway #422 (merged as e5b802a25dc2631e9dfb74f86157506e5740fd15) into the bundled `gateway/ai/server.py`. Consequence class C2. Return class: customer (Glama listing, 6,612 profile views / 30d, builds from this repo's main) and correctness.

server.py now inserts its own directory and the gateway root on `sys.path` before the first `from ai...` import. Launchers that start it directly without PYTHONPATH (Glama's image start command, Docker ENTRYPOINTs) no longer die with `ModuleNotFoundError: No module named 'ai'`; launchers that set PYTHONPATH see no change. Real-path proof at the gateway PR: Glama's recipe with the PYTHONPATH ENV removed keeps the fixed server alive under mcp-proxy as PID 1 (proxy HTTP 200), while the unfixed 4.18.3 control exits 1 with the exact Glama error.

Verification: bundled copy byte-identical to gateway main e5b802a25dc2631e9dfb74f86157506e5740fd15 by sha256; `scripts/sync-gateway.sh` allowlist model (nothing outside the allowlist copied); npm test green on this head.

Glama builds from this repo's main HEAD (its last build spec checked out 530c822, not a tag), so merging this makes its next build attempt succeed without waiting for the npm release. The npm release that ships it to CLI users remains founder-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jPtqdWpeRvDBDBP5sWSbT
