### PR TITLE
Fix Codex deliberation transport timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Fixed
+- Codex setup now gives the Delimit MCP server a 30-minute tool-call window, so legitimate multi-round deliberations are not detached by the client's shorter default timeout while the panel is still responding.
 - Pro engine modules now resolve to v3.10.1, rebuilt on Ubuntu 22.04 so the compiled deliberation, governance and license modules load on Debian 12 and Ubuntu 22.04 (v3.10.0 required glibc 2.38 and failed to import there, which left hosted deliberation dead and license gating on the Python fallback). Existing installs pick the new engine up on their next `delimit setup`.
 
 ## [4.18.3] - 2026-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Codex setup now gives the Delimit MCP server a 30-minute tool-call window, so legitimate multi-round deliberations are not detached by the client's shorter default timeout while the panel is still responding.
+- The fresh-install funnel tests now strip inherited `GIT_*` variables before creating temporary repositories; when invoked from a Git pre-push hook, they can no longer turn the real package checkout into a bare repository or commit test fixtures onto the release branch.
 - Pro engine modules now resolve to v3.10.1, rebuilt on Ubuntu 22.04 so the compiled deliberation, governance and license modules load on Debian 12 and Ubuntu 22.04 (v3.10.0 required glibc 2.38 and failed to import there, which left hosted deliberation dead and license gating on the Python fallback). Existing installs pick the new engine up on their next `delimit setup`.
 
 ## [4.18.3] - 2026-09-04

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ npx delimit-cli deliberate "Is dropping the deprecated v1 /users field a safe MI
 #   tool: delimit_deliberate — 3 hosted runs after `delimit signin` (free account), then bring your own keys
 ```
 
+`delimit setup` gives the Codex MCP server a 30-minute tool timeout so a
+multi-round panel can return its completed transcript instead of being detached
+by the client while its models are still responding.
+
 **Capture the signed, replayable attestation.** After a gate event (deploy / security / test / audit), record the evidence bundle and verify it any time.
 
 ```text

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -352,8 +352,10 @@ async function main() {
             fs.chmodSync(CODEX_CONFIG, 0o644);
             let toml = fs.readFileSync(CODEX_CONFIG, 'utf-8');
             const serverDir = path.join(DELIMIT_HOME, 'server');
-            // approval_policy = "never" means auto-approve all tools from this server (no per-prompt confirmations)
-            const correctEntry = `\n[mcp_servers.delimit]\ncommand = "${python}"\nargs = ["${actualServer}"]\ncwd = "${serverDir}"\napproval_policy = "never"\n\n[mcp_servers.delimit.env]\nPYTHONPATH = "${serverDir}:${path.join(serverDir, 'ai')}"\n`;
+            // approval_policy = "never" means auto-approve all tools from this server (no per-prompt confirmations).
+            // Deliberation intentionally runs several independent model calls;
+            // give the MCP transport the same 30-minute ceiling as the engine.
+            const correctEntry = `\n[mcp_servers.delimit]\ncommand = "${python}"\nargs = ["${actualServer}"]\ncwd = "${serverDir}"\napproval_policy = "never"\ntool_timeout_sec = 1800\n\n[mcp_servers.delimit.env]\nPYTHONPATH = "${serverDir}:${path.join(serverDir, 'ai')}"\n`;
             // Remove ALL existing delimit MCP entries (prevents duplicates)
             const existed = toml.includes('mcp_servers.delimit');
             const lines = toml.split('\n');

--- a/tests/funnel-cli-leaks.test.js
+++ b/tests/funnel-cli-leaks.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawnSync } = require('child_process');
-const { makeTmpGitRepo } = require('./_git-hermetic');
+const { gitEnv, makeTmpGitRepo } = require('./_git-hermetic');
 
 /**
  * Fresh-user install test of delimit-cli 4.18.1 (2026-09-02) found five
@@ -37,7 +37,7 @@ function runCli(args, { cwd, home, env = {}, timeout = 60000 } = {}) {
         timeout,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: {
-            ...process.env,
+            ...gitEnv(cwd),
             HOME: home,
             DELIMIT_HOME: delimitHome,
             CI: '1',
@@ -356,14 +356,15 @@ describe('delimit check --staged on an unborn HEAD keeps pre-commit isolation (P
         const dir = path.join(home, 'repo');
         fs.mkdirSync(dir, { recursive: true });
         try {
-            execSync('git init -q', { cwd: dir });
+            const env = gitEnv(dir);
+            execSync('git init -q', { cwd: dir, env });
             const spec = (title) => `openapi: 3.0.0\ninfo:\n  title: ${title}\n  version: 1.0.0\npaths: {}\n`;
             fs.writeFileSync(path.join(dir, 'staged-openapi.yaml'), spec('staged'));
             fs.writeFileSync(path.join(dir, 'untracked-openapi.yaml'), spec('untracked'));
-            execSync('git add staged-openapi.yaml', { cwd: dir });
+            execSync('git add staged-openapi.yaml', { cwd: dir, env });
             const r = spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'check', '--staged'], {
                 cwd: dir, encoding: 'utf-8', timeout: 60000,
-                env: { ...process.env, HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
+                env: { ...gitEnv(dir), HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
                 stdio: ['ignore', 'pipe', 'pipe'],
             });
             const out = r.stdout + r.stderr;
@@ -382,10 +383,11 @@ describe('delimit check --staged: an empty index is authoritative (PR #199 r2 fo
     function repo(withCommit) {
         const home = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-empty-staged-'));
         const dir = path.join(home, 'repo'); fs.mkdirSync(dir, { recursive: true });
-        execSync('git init -q', { cwd: dir });
+        const env = gitEnv(dir);
+        execSync('git init -q', { cwd: dir, env });
         if (withCommit) {
             fs.writeFileSync(path.join(dir, 'README.md'), 'x\n');
-            execSync('git add README.md && git -c user.email=t@e.c -c user.name=t commit -qm init', { cwd: dir });
+            execSync('git add README.md && git -c user.email=t@e.c -c user.name=t commit -qm init', { cwd: dir, env });
         }
         // An UNTRACKED spec at a known location: the old fallback would have scanned it.
         fs.writeFileSync(path.join(dir, 'openapi.yaml'), 'openapi: 3.0.0\ninfo:\n  title: untracked\n  version: 1.0.0\npaths: {}\n');
@@ -394,7 +396,7 @@ describe('delimit check --staged: an empty index is authoritative (PR #199 r2 fo
     function run(dir, home) {
         return spawnSync(process.execPath, [path.join(__dirname, '..', 'bin', 'delimit-cli.js'), 'check', '--staged'], {
             cwd: dir, encoding: 'utf-8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'],
-            env: { ...process.env, HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
+            env: { ...gitEnv(dir), HOME: home, DELIMIT_HOME: path.join(home, '.delimit'), CI: '1', NO_COLOR: '1' },
         });
     }
     for (const [label, withCommit] of [['unborn HEAD', false], ['repo with commits', true]]) {

--- a/tests/setup-matrix.test.js
+++ b/tests/setup-matrix.test.js
@@ -69,6 +69,7 @@ describe('setup matrix: config file structure', () => {
 command = "/usr/bin/python3"
 args = ["/home/test/.delimit/server/ai/server.py"]
 cwd = "/home/test/.delimit/server"
+tool_timeout_sec = 1800
 
 [mcp_servers.delimit.env]
 PYTHONPATH = "/home/test/.delimit/server"
@@ -80,6 +81,7 @@ PYTHONPATH = "/home/test/.delimit/server"
         assert.ok(result.includes('command'), 'Should have command key');
         assert.ok(result.includes('python'), 'Command should be python');
         assert.ok(result.includes('server.py'), 'Should reference server.py');
+        assert.ok(result.includes('tool_timeout_sec = 1800'), 'Should allow long deliberation calls');
     });
 
     it('Cursor: creates valid ~/.cursor/mcp.json with delimit entry', () => {

--- a/tests/setup-onboarding.test.js
+++ b/tests/setup-onboarding.test.js
@@ -440,6 +440,15 @@ describe('setup script structure', () => {
         // Cursor rules path unchanged.
         assert.ok(setupContent.includes('cursorRules'), 'Should handle cursor rules');
     });
+
+    it('setup gives the Delimit Codex MCP server enough time for deliberation', () => {
+        const setupPath = path.join(__dirname, '..', 'bin', 'delimit-setup.js');
+        const setupContent = fs.readFileSync(setupPath, 'utf-8');
+        assert.ok(
+            setupContent.includes('tool_timeout_sec = 1800'),
+            'Codex MCP setup must preserve the 30-minute deliberation transport window'
+        );
+    });
 });
 
 describe('spec auto-detection', () => {


### PR DESCRIPTION
## Summary
- configure Codex's Delimit MCP server with a 30-minute tool timeout
- document the transport window and cover setup output with tests
- make temporary Git repositories hermetic under inherited pre-push hook variables

## Evidence
- npm test: 385 passed
- inherited-GIT_DIR regression: 25 passed; sentinel repo unchanged
- pre-push guard: passed; package core.bare remained false
- independent Delimit review: unanimous, 4 respondents / 3 vendors

## Why
A five-seat Delimit debate completed successfully after 365 seconds, but the Codex client detached at 300 seconds. The engine concurrency correction is tracked in the companion gateway PR.