### PR TITLE
fix(LED-4057): restore venture-bound cross-model continuity

### DIFF
--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
+const crypto = require('crypto');
 const chalk = require('chalk');
 const { spawnSync, execSync } = require('child_process');
+const { delimitHome } = require('./delimit-home');
 
 // Banner version is read from package.json so it never goes stale per release.
 const PKG_VERSION = (() => { try { return require('../package.json').version; } catch (e) { return ''; } })();
@@ -89,10 +90,20 @@ class DelimitChatREPL {
         // --model <id>: launch a specific model first this session, leaving the
         // default fallback chain (and models.json) untouched. null = normal chain.
         this.launchModel = options.model || null;
+        // LED-4057: one stable identity spans every model/hook in this launcher
+        // process. Session Phoenix uses it as binding metadata while logical
+        // harness session ids remain the canonical dedup identity.
+        this.chatRunId = options.chatRunId || process.env.DELIMIT_CHAT_RUN_ID
+            || (typeof crypto.randomUUID === 'function'
+                ? crypto.randomUUID()
+                : crypto.randomBytes(16).toString('hex'));
+        this._spawnSync = options.spawnSync || spawnSync;
+        this.sessionPhoenixRoot = options.sessionPhoenixRoot
+            || path.join(delimitHome(), 'server');
     }
 
     loadModels() {
-        const modelsPath = path.join(os.homedir(), '.delimit', 'models.json');
+        const modelsPath = path.join(delimitHome(), 'models.json');
         if (fs.existsSync(modelsPath)) {
             try {
                 return JSON.parse(fs.readFileSync(modelsPath, 'utf-8'));
@@ -104,7 +115,7 @@ class DelimitChatREPL {
     }
 
     loadRoutes() {
-        const routesPath = path.join(os.homedir(), '.delimit', 'routes.json');
+        const routesPath = path.join(delimitHome(), 'routes.json');
         if (fs.existsSync(routesPath)) {
             try {
                 return JSON.parse(fs.readFileSync(routesPath, 'utf-8'));
@@ -142,77 +153,104 @@ class DelimitChatREPL {
         return activeModels;
     }
 
-    // Capture the DYING session's real context before Auto-Phoenix switches
-    // models, so the next agent revives actual work — not a thin marker.
-    //
-    // LED-1962: this used to call capture_soul(active_task="Auto-Phoenix
-    // migration from X") with everything else empty. That wrote a THIN soul
-    // (no decisions / next-steps) that (a) became the newest soul and shadowed
-    // the real context, and (b) stamped .last_capture — which made the NEXT
-    // session's SessionStart reconcile_orphan skip salvaging the dying model's
-    // transcript. Both defeated the point of the capture.
-    //
-    // Fix: use reconcile_orphan (LED-1705/3711) — it salvages the dying model's
-    // transcript tail (cross-harness) into a rich floor soul, and its
-    // .last_capture guard means it never clobbers a fresh model-authored soul
-    // (returns "skipped/last_capture_present" — the rich soul already exists).
-    // Only when there is genuinely nothing to salvage do we fall back to the
-    // old thin capture, so we never lose the git-state floor. Returns true if
-    // anything was captured/left in place. Resolves the server path at runtime.
-    captureSoulForMigration(fromModel) {
-        const candidates = [
-            path.join(__dirname, '..', 'gateway'),
-            path.join(os.homedir(), '.delimit', 'server'),
-        ];
-        for (const base of candidates) {
-            if (!fs.existsSync(path.join(base, 'ai', 'session_phoenix.py'))) continue;
-            try {
-                const pyCmd = `import sys; sys.path.insert(0, ${JSON.stringify(base)}); `
-                    + `from ai.session_phoenix import reconcile_orphan, capture_soul\n`
-                    + `r = reconcile_orphan() or {}\n`
-                    + `status = r.get("status"); reason = r.get("reason", "")\n`
-                    + `# reconciled = rich salvage done; skipped+last_capture_present = a\n`
-                    + `# fresh rich soul already exists. Either way, do NOT write a thin\n`
-                    + `# marker. Only floor-capture when nothing is salvageable.\n`
-                    + `if not (status == "reconciled" or (status == "skipped" and reason == "last_capture_present")):\n`
-                    + `    capture_soul(active_task=${JSON.stringify('Auto-Phoenix migration from ' + fromModel)})\n`;
-                // LED-1964: time-box the spawn so a hung python can't stall the
-                // Auto-Phoenix migration. On timeout r.status is null (not 0), so
-                // we fall through to the next candidate / return false (fail-open).
-                const r = spawnSync('python3', ['-c', pyCmd], { stdio: 'ignore', timeout: 6000 });
-                if (r.status === 0) return true;
-            } catch (e) { /* try next candidate */ }
+    // Invoke the installed Session Phoenix backend and return its structured
+    // verdict. The launcher never guesses a transcript/project or treats a
+    // zero process exit as proof that a durable capture exists.
+    _runSessionPhoenix(functionName, payload) {
+        const base = this.sessionPhoenixRoot;
+        if (!fs.existsSync(path.join(base, 'ai', 'session_phoenix.py'))) {
+            return { status: 'unavailable', reason: 'backend_missing' };
         }
-        return false;
+        try {
+            const pyCmd = [
+                'import inspect, json, sys',
+                `sys.path.insert(0, ${JSON.stringify(base)})`,
+                'from ai import session_phoenix as backend',
+                `fn = getattr(backend, ${JSON.stringify(functionName)}, None)`,
+                'protocol = int(getattr(backend, "CONTINUITY_PROTOCOL_VERSION", 0))',
+                'proposed = json.loads(sys.argv[1])',
+                'params = inspect.signature(fn).parameters if callable(fn) else {}',
+                'result = (fn(**{k: v for k, v in proposed.items() if k in params}) or {}) if protocol >= 2 and callable(fn) else {"status": "unavailable", "reason": "incompatible_backend"}',
+                'print(json.dumps(result))',
+            ].join('; ');
+            const r = this._spawnSync(
+                'python3',
+                ['-c', pyCmd, JSON.stringify(payload)],
+                {
+                    encoding: 'utf-8',
+                    timeout: 6000,
+                    env: {
+                        ...process.env,
+                        DELIMIT_CHAT_RUN_ID: this.chatRunId,
+                    },
+                },
+            );
+            if (r.status !== 0 || !r.stdout || !r.stdout.trim()) {
+                return { status: 'unavailable', reason: 'backend_call_failed' };
+            }
+            return JSON.parse(r.stdout.trim().split('\n').pop());
+        } catch (e) {
+            return { status: 'unavailable', reason: 'backend_call_failed' };
+        }
     }
 
-    // LED-1962: Revive the CURRENT-PROJECT soul as a plain context string, for
-    // injecting into a launched model that has NO session-start injection hook
-    // (Codex). Claude Code revives via its SessionStart hook, so we never inject
-    // for claude (that would double the context). Current-project only —
-    // `delimit chat` switches models IN THE SAME cwd, so a cross-project global
-    // scan is unnecessary and would risk cross-venture bleed. Returns the
-    // formatted soul, or "" if none / unavailable. Fail-open, time-boxed.
+    captureSoulForMigration(fromModel, toModel = '', options = {}) {
+        return this._runSessionPhoenix('capture_floor_from_transcript', {
+            transcript_path: '',
+            project_path: '',
+            source_model: fromModel || '',
+            to_model: toModel || '',
+            chat_run_id: this.chatRunId,
+            trigger: options.trigger || 'launcher-migration',
+            reason: options.reason || '',
+            finalize: Boolean(options.finalize),
+        });
+    }
+
     reviveSoulForLaunch() {
-        const candidates = [
-            path.join(__dirname, '..', 'gateway'),
-            path.join(os.homedir(), '.delimit', 'server'),
-        ];
-        for (const base of candidates) {
-            if (!fs.existsSync(path.join(base, 'ai', 'session_phoenix.py'))) continue;
-            try {
-                const pyCmd = `import sys; sys.path.insert(0, ${JSON.stringify(base)}); `
-                    + `from ai.session_phoenix import get_latest_soul, _format_revival; `
-                    + `s = get_latest_soul(); `
-                    + `sys.stdout.write(_format_revival(s)) if s is not None else None`;
-                const r = spawnSync('python3', ['-c', pyCmd], { encoding: 'utf-8', timeout: 6000 });
-                if (r.status === 0 && r.stdout && r.stdout.trim()) return r.stdout.trim();
-                // LED-1964: fall through to the next candidate (bundled gateway ->
-                // installed server) on a failed/empty first candidate, instead of
-                // returning "" prematurely; only give up after both are exhausted.
-            } catch (e) { /* try next candidate */ }
+        return this._runSessionPhoenix('revive', {
+            project_path: '',
+            soul_id: '',
+            scope: '',
+            transcript_path: '',
+            chat_run_id: this.chatRunId,
+            allow_global_fallback: false,
+        });
+    }
+
+    acknowledgeCodexRevival(revival, childResult) {
+        const deliveryAck = revival?.delivery_ack;
+        if (!deliveryAck?.capture_key || !deliveryAck?.write_id) {
+            return { status: 'skipped', reason: 'no_delivery_generation' };
         }
-        return '';
+        // The positional prompt crosses the exec boundary before Codex can
+        // return cleanly. Keep the generation retryable for spawn failures,
+        // signals, and non-zero exits: those paths do not prove the model
+        // accepted the revived context.
+        if (childResult?.status !== 0 || childResult?.signal || childResult?.error) {
+            return { status: 'retryable', reason: 'delivery_not_confirmed' };
+        }
+        return this._runSessionPhoenix('acknowledge_revival', deliveryAck);
+    }
+
+    captureSucceeded(result) {
+        return ['captured', 'updated', 'deduplicated', 'finalized', 'already_captured', 'noop']
+            .includes(String(result?.status || ''));
+    }
+
+    formatContinuityCandidates(candidates) {
+        if (!Array.isArray(candidates) || candidates.length === 0) {
+            return 'multiple ventures';
+        }
+        return candidates.slice(0, 5).map((candidate) => {
+            if (typeof candidate === 'string') return candidate;
+            if (!candidate || typeof candidate !== 'object') return String(candidate);
+            return candidate.name
+                || candidate.venture
+                || candidate.project_path
+                || candidate.repoRoot
+                || 'unknown venture';
+        }).join(', ');
     }
 
     // LED-1710: validate cross-agent handoff invariants (committer identity,
@@ -222,7 +260,7 @@ class DelimitChatREPL {
     preflightHandoff(repoPath) {
         const candidates = [
             path.join(__dirname, '..', 'gateway'),
-            path.join(os.homedir(), '.delimit', 'server'),
+            path.join(delimitHome(), 'server'),
         ];
         for (const base of candidates) {
             if (!fs.existsSync(path.join(base, 'ai', 'handoff_preflight.py'))) continue;
@@ -253,7 +291,7 @@ class DelimitChatREPL {
     getControlBrief() {
         const candidates = [
             path.join(__dirname, '..', 'gateway'),
-            path.join(os.homedir(), '.delimit', 'server'),
+            path.join(delimitHome(), 'server'),
         ];
         for (const base of candidates) {
             if (!fs.existsSync(path.join(base, 'ai', 'control_plane.py'))) continue;
@@ -518,7 +556,7 @@ class DelimitChatREPL {
             console.log(chalk.magenta.bold(`  [Delimit] `) + chalk.magenta(`<`) + chalk.yellow(`/`) + chalk.magenta(`> `) + chalk.bold(`GOVERNANCE ACTIVE: ${activeModel.id.toUpperCase()}`));
             console.log(chalk.magenta.bold(`  [Delimit] `) + chalk.magenta(`═══════════════════════════════════════════\n`));
 
-            const shimPath = path.join(os.homedir(), '.delimit', 'shims', activeModel.id);
+            const shimPath = path.join(delimitHome(), 'shims', activeModel.id);
             if (!fs.existsSync(shimPath)) {
                 console.log(chalk.red(`  Error: Shim not found for ${activeModel.id} at ${shimPath}`));
                 this.failedModels.add(activeModel.id);
@@ -565,20 +603,26 @@ class DelimitChatREPL {
             // `exec codex "$@"`, so a positional arg reaches codex as [PROMPT].
             // Claude is intentionally excluded (its hook already injects; doubling
             // would just bloat context). Fail-open: no soul -> launch unchanged.
+            let pendingCodexRevival = null;
             if (activeModel.id === 'codex') {
-                const soul = this.reviveSoulForLaunch();
-                if (soul) {
+                const revival = this.reviveSoulForLaunch();
+                if (revival?.status === 'revived' && revival.context) {
                     args.push(
                         '[Auto-revived session context — you just switched agents '
                         + '(e.g. a quota limit). This is where the previous agent left '
-                        + 'off. Read it, then continue.]\n\n' + soul
+                        + 'off. Read it, then continue.]\n\n' + revival.context
                     );
+                    pendingCodexRevival = revival;
+                } else if (['ambiguous', 'blocked_ambiguity'].includes(revival?.status)) {
+                    const choices = this.formatContinuityCandidates(revival.candidates);
+                    console.log(chalk.yellow(`  ⚠ Continuity ambiguity (${choices}); no soul was injected.`));
                 }
             }
 
             const env = { ...process.env };
             // Suppress the shim banner so it feels like a native session
             env.DELIMIT_QUIET = 'true';
+            env.DELIMIT_CHAT_RUN_ID = this.chatRunId;
             
             const p = this.modelsConfig[activeModel.id];
             
@@ -639,9 +683,28 @@ class DelimitChatREPL {
             const result = spawnSync(shimPath, args, { stdio: 'inherit', env });
             process.removeListener('SIGINT', sigintHandler);
 
+            if (pendingCodexRevival) {
+                // Phase two happens only after a clean child return proves the
+                // positional context crossed the Codex exec boundary. A failed
+                // or interrupted launch deliberately leaves the pointer
+                // unacknowledged so the next model/run can retry it.
+                this.acknowledgeCodexRevival(pendingCodexRevival, result);
+            }
+
             if (result.status === 0) {
-                // Clean exit (user typed /exit)
-                console.log(chalk.gray('\n  Session saved. Exiting Delimit.'));
+                // Clean exit (user typed /exit). Finalize only an already
+                // project-bound logical session; the backend must not guess a
+                // stale transcript for a fresh non-Claude session.
+                const finalized = this.captureSoulForMigration(
+                    activeModel.id,
+                    '',
+                    { trigger: 'launcher-clean-exit', reason: 'clean-exit', finalize: true },
+                );
+                if (this.captureSucceeded(finalized)) {
+                    console.log(chalk.gray('\n  Session saved. Exiting Delimit.'));
+                } else {
+                    console.log(chalk.yellow('\n  Session exited, but project-bound context save was unavailable.'));
+                }
                 process.exit(0);
             } else if (result.signal === 'SIGINT') {
                 console.log(chalk.yellow('\n  Session interrupted (Ctrl+C).'));
@@ -651,11 +714,17 @@ class DelimitChatREPL {
                     this.failedModels.add(activeModel.id);
 
                     // Capture context before switching, then advance the chain.
-                    const captured = this.captureSoulForMigration(activeModel.id);
+                    const nextModel = chain.length > 1 ? chain[1] : null;
+                    const captured = this.captureSoulForMigration(
+                        activeModel.id,
+                        nextModel?.id || '',
+                        { trigger: 'launcher-interrupt', reason: 'sigint' },
+                    );
                     if (chain.length > 1) {
-                        const nextModel = chain[1];
-                        if (captured) {
+                        if (this.captureSucceeded(captured)) {
                             console.log(chalk.green(`  ✓ Context saved — ${chalk.bold(nextModel.id)} will revive it on start.`));
+                        } else if (['ambiguous', 'blocked_ambiguity'].includes(captured?.status)) {
+                            console.log(chalk.yellow(`  ⚠ Venture ambiguity — no context injected into ${chalk.bold(nextModel.id)}.`));
                         } else {
                             console.log(chalk.yellow(`  ⚠ Switching to ${chalk.bold(nextModel.id)} (context save unavailable).`));
                         }
@@ -673,11 +742,17 @@ class DelimitChatREPL {
                 this.failedModels.add(activeModel.id);
 
                 // Capture context before switching, then advance the chain.
-                const captured = this.captureSoulForMigration(activeModel.id);
+                const nextModel = chain.length > 1 ? chain[1] : null;
+                const captured = this.captureSoulForMigration(
+                    activeModel.id,
+                    nextModel?.id || '',
+                    { trigger: 'launcher-failure', reason: `exit-${result.status}` },
+                );
                 if (chain.length > 1) {
-                    const nextModel = chain[1];
-                    if (captured) {
+                    if (this.captureSucceeded(captured)) {
                         console.log(chalk.green(`  ✓ Context saved — ${chalk.bold(nextModel.id)} will revive it on start.`));
+                    } else if (['ambiguous', 'blocked_ambiguity'].includes(captured?.status)) {
+                        console.log(chalk.yellow(`  ⚠ Venture ambiguity — no context injected into ${chalk.bold(nextModel.id)}.`));
                     } else {
                         console.log(chalk.yellow(`  ⚠ Switching to ${chalk.bold(nextModel.id)} (context save unavailable).`));
                     }

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -985,7 +985,30 @@ except Exception:
     pass
 result_text = result_text[:2000]
 
-venture = os.path.basename(cwd.rstrip("/")) or "all"
+def _resolve_venture(cwd):
+    # LED-4244: a NEUTRAL cwd (portfolio roots like /root, /home/<user>, /)
+    # must not become the venture name. Prefer the active-venture registry
+    # maintained by the CLI resolver (~/.delimit/active_venture.json);
+    # fall back to the cwd basename; "all" only when nothing resolves.
+    base = os.path.basename(cwd.rstrip("/")) or ""
+    home = os.path.expanduser("~")
+    neutral = (
+        not base
+        or cwd.rstrip("/") in ("", "/", home)
+        or base in ("root", "home")
+    )
+    if neutral:
+        try:
+            with open(os.path.join(home, ".delimit", "active_venture.json")) as fh:
+                reg = json.load(fh)
+            v = str((reg or {}).get("venture") or "").strip()
+            if v:
+                return v
+        except Exception:
+            pass
+    return base or "all"
+
+venture = _resolve_venture(cwd)
 ext_key = "harness:%s:%s" % (
     session_id[:12],
     hashlib.sha1((prompt or title).encode("utf-8", "replace")).hexdigest()[:10],

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -16,13 +16,14 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
+const { delimitHome } = require('./delimit-home');
 
 // LED-213: Import canonical template for cross-model parity
 const { getDelimitSection, getDelimitSectionCondensed } = require('./delimit-template');
 
 // Use process.env.HOME to allow test overrides; fall back to os.homedir()
 function getHome() { return process.env.HOME || os.homedir(); }
-function getDelimitHome() { return path.join(getHome(), '.delimit'); }
+function getDelimitHome() { return delimitHome(); }
 
 function readJsonl(filePath) {
     if (!fs.existsSync(filePath)) {
@@ -148,13 +149,11 @@ function loadHookConfig() {
         // LED-1962: SessionStart AUTO-REVIVES the last working soul into the new
         // session (not just a hint to run delimit_revive). This is how a
         // quota-driven agent switch resumes context. Default on; additive + reversible.
-        // Scoped to the CURRENT project by default.
+        // Scoped to the event-bound active project.
         session_auto_revive: true,
-        // LED-1962: cross-project fallback is OPT-IN, default OFF. A soul captured
-        // under a DIFFERENT project/venture must not bleed into an unrelated
-        // (possibly public) repo session by default, since its context could
-        // propagate into that session's commits/PRs/transcripts. Enable only for
-        // cross-worktree/cross-venture quota-switch continuity (power-user opt-in).
+        // Retained only so older config files still parse. LED-4057 retired
+        // blind global-most-recent revival; explicit soul-id revival is the
+        // intentional cross-project path.
         session_auto_revive_global: false,
     };
 
@@ -375,7 +374,6 @@ function installClaudeHooks(tool, hookConfig) {
         const hooksDir = path.join(home, '.claude', 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         const hookScript = path.join(hooksDir, 'delimit');
-        const delimitHome = path.join(home, '.delimit');
         // STR-2202: SessionStart digest + heartbeat echo (HOOK half of "tools
         // fire tools"). Closes the "cron computes, nothing reads" loop — the
         // daily digest already counts stuck dispatches / signals and the
@@ -424,340 +422,100 @@ except Exception:
 DGEOF
 fi
 `);
-        // LED-1962: AUTO-REVIVE the last working soul into the session (not just
-        // a hint). SessionStart stdout is injected into the new session, so
-        // emitting the prior soul HERE is what makes "switch AI coding agents
-        // without losing the plot" actually happen: a fresh Claude Code OR Codex
-        // session (e.g. after a quota switch) starts WITH the last
-        // task/decisions/next-steps already in context, instead of only being
-        // told to go run delimit_revive itself. Imports ai.session_phoenix from
-        // the installed server (~/.delimit/server), orchestrator-only, time-boxed
-        // (6s), fail-open. Gated by the session_auto_revive config flag (default
-        // on; additive + reversible).
-        //
-        // SCOPE: current project ONLY by default. Cross-project fallback (resume
-        // the globally-most-recent soul across ALL projects) is OPT-IN via
-        // session_auto_revive_global — otherwise a soul captured under a different
-        // project/venture could bleed into an unrelated (possibly public) repo
-        // session and propagate into its commits/PRs. The opt-in is passed to the
-        // block as the DELIMIT_AUTO_REVIVE_GLOBAL env var ("1" when enabled).
-        //
-        // No JS interpolation lives inside the RVEOF heredoc — the python f-string
-        // uses bare {origin} (no dollar-brace), so it survives into the generated
-        // script verbatim. ${autoReviveGlobalEnv} is interpolated only on the bash
-        // env-assignment line (outside the quoted heredoc).
-        const autoReviveGlobalEnv = (hookConfig.session_auto_revive_global === true) ? '1' : '';
-        const autoReviveBlock = (hookConfig.session_auto_revive === false) ? '' : (`
-# LED-1962: AUTO-REVIVE the last working soul into the session (not just a hint).
-# SessionStart stdout is injected into the new session, so emitting the prior
-# soul HERE is what makes "switch AI coding agents without losing the plot"
-# actually happen: a fresh Claude Code OR Codex session (e.g. after a quota
-# switch) starts WITH the last task/decisions/next-steps already in context,
-# instead of only being told to go run delimit_revive itself.
-# Current project by default; cross-project resume is opt-in (DELIMIT_AUTO_REVIVE_GLOBAL).
-# Orchestrator-only (subagents get scoped handoffs); time-boxed; fail-open.
-if [ "$DELIMIT_SESSION_TYPE" != "subagent" ] && [ "$DELIMIT_SESSION_TYPE" != "agent" ]; then
-  DELIMIT_HOME="$DELIMIT_HOME" DELIMIT_AUTO_REVIVE_GLOBAL="${autoReviveGlobalEnv}" timeout 6 python3 - <<'RVEOF' 2>/dev/null || true
-import os, sys
-from pathlib import Path
-HOME = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
-for _p in (str(HOME / "server"), "/home/delimit/delimit-gateway"):
-    if os.path.isdir(_p) and _p not in sys.path:
-        sys.path.insert(0, _p)
-try:
-    from ai.session_phoenix import (
-        get_latest_soul, find_most_recent_soul_across_projects, _format_revival,
-    )
-except Exception:
-    sys.exit(0)
-try:
-    cwd = os.getcwd()
-    soul = get_latest_soul(cwd)
-    origin = cwd
-    # Cross-project fallback is OPT-IN: only when session_auto_revive_global is
-    # enabled do we resume the globally-most-recent soul (for cross-worktree
-    # quota-switch continuity). By default a soul from a DIFFERENT project never
-    # bleeds into this session.
-    if os.environ.get("DELIMIT_AUTO_REVIVE_GLOBAL") == "1":
-        glob_ = find_most_recent_soul_across_projects()
-        other = glob_.get("soul") if glob_ else None
-        other_path = (glob_ or {}).get("project_path", "")
-        if other is not None and (soul is None or (other.created_at or "") > (soul.created_at or "")):
-            soul, origin = other, other_path
-    if soul is None:
-        sys.exit(0)
-    print("  === Auto-revived working context (last soul) ===")
-    if origin and os.path.realpath(origin) != os.path.realpath(cwd):
-        print(f"  (most-recent soul, captured under {origin})")
-    print(_format_revival(soul))
-except Exception:
-    sys.exit(0)
-RVEOF
-fi
-`);
+        // SessionStart must reconcile and revive in one backend process.  The
+        // reconciler returns an exact project+soul reference; feeding the new,
+        // empty SessionStart transcript into a second resolver loses that
+        // identity and can either inject nothing or select the wrong venture.
+        const autoReviveEnabled = hookConfig.session_auto_revive !== false;
         // Write hook script — use explicit newline prefix to avoid terminal escape contamination
         const scriptContent = '#!/bin/bash\n' + `
-# Delimit SessionStart — generated by delimit-cli setup
-DELIMIT_HOME="\${DELIMIT_HOME:-${delimitHome}}"
+# Delimit SessionStart — thin Session Phoenix delegates.
+DELIMIT_HOME="\$DELIMIT_HOME"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$DELIMIT_NAMESPACE_ROOT"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$HOME/.delimit"
+SESSIONSTART_EVENT_JSON="\$(cat 2>/dev/null || true)"
 
-# LED-1705: crash-gap reconciliation. Claude Code passes the SessionStart
-# event as JSON on stdin (session_id, transcript_path). If the PRIOR session
-# was SIGKILLed (Stop hook never fired -> no .last_capture stamp), salvage a
-# cheap deterministic floor handoff from its orphaned transcript. The newest
-# transcript at session start is the CURRENT session's, so we exclude it and
-# salvage the next-most-recent. Time-boxed, best-effort, never blocks start.
-SESSIONSTART_EVENT_JSON="$(cat 2>/dev/null || true)"
-DELIMIT_HOME="$DELIMIT_HOME" SESSIONSTART_EVENT_JSON="$SESSIONSTART_EVENT_JSON" \\
-  timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
-import json, os, sys, time, subprocess
+${digestEchoBlock}
+echo "  === Delimit Ready ==="
+
+# Continuity is deliberately LAST.  Its two-phase acknowledgement follows a
+# successful stdout flush, and no earlier optional work may exhaust the outer
+# hook budget after that acknowledgement.
+if [ "\$DELIMIT_SESSION_TYPE" != "subagent" ] && [ "\$DELIMIT_SESSION_TYPE" != "agent" ]; then
+DELIMIT_HOME="\$DELIMIT_HOME" SESSIONSTART_EVENT_JSON="\$SESSIONSTART_EVENT_JSON" \
+  DELIMIT_CHAT_RUN_ID="\${DELIMIT_CHAT_RUN_ID:-}" timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
+import inspect, json, os, sys
 from pathlib import Path
-
-HOME = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
-stamp_path = HOME / ".last_capture"
-
-# Double-reconcile / clean-exit guard: any stamp means the prior session was
-# already captured (cleanly OR by an earlier reconcile) -- nothing to salvage.
+home = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
+server = str(home / "server")
+if not os.path.isdir(server):
+    sys.exit(0)
+sys.path.insert(0, server)
 try:
-    if stamp_path.exists():
-        json.loads(stamp_path.read_text())
+    from ai import session_phoenix as backend
+    if int(getattr(backend, "CONTINUITY_PROTOCOL_VERSION", 0)) < 2:
         sys.exit(0)
-except Exception:
-    pass
+    reconcile_orphan = backend.reconcile_orphan
+    revive = backend.revive
+    acknowledge_revival = getattr(backend, "acknowledge_revival", None)
+    event = json.loads(os.environ.get("SESSIONSTART_EVENT_JSON", "") or "{}")
+    launcher_run = os.environ.get("DELIMIT_CHAT_RUN_ID", "")
 
-# Parse SessionStart event for the CURRENT transcript path (to exclude it).
-cur_transcript = ""
-try:
-    ev = json.loads(os.environ.get("SESSIONSTART_EVENT_JSON", "") or "{}")
-    cur_transcript = ev.get("transcript_path", "") or ""
-except Exception:
-    pass
-if not cur_transcript:
-    sys.exit(0)
+    def call(fn, proposed):
+        params = inspect.signature(fn).parameters
+        return fn(**{k: v for k, v in proposed.items() if k in params}) or {}
 
-# Find the newest sibling transcript that isn't the current session's.
-try:
-    cur = Path(cur_transcript)
-    proj_dir = cur.parent
-    cur_real = os.path.realpath(str(cur))
-    cands = [f for f in proj_dir.glob("*.jsonl") if os.path.realpath(str(f)) != cur_real]
-    if not cands:
+    result = call(reconcile_orphan, {
+        "transcript_path": "",
+        "project_path": "",
+        "current_transcript_path": event.get("transcript_path", "") or "",
+        "session_id": event.get("session_id", "") or "",
+        "reason": event.get("reason", "session-start") or "session-start",
+        "chat_run_id": launcher_run,
+    })
+    status = str(result.get("status", ""))
+    if status in ("ambiguous", "blocked_ambiguity"):
+        choices = result.get("candidates") or []
+        print("  ⚠ Delimit continuity is ambiguous; no venture was revived: " + ", ".join(map(str, choices[:5])))
         sys.exit(0)
-    orphan = str(max(cands, key=lambda f: f.stat().st_mtime))
-except Exception:
-    sys.exit(0)
 
-def run_git(args):
-    try:
-        r = subprocess.run(["git"] + args, capture_output=True, text=True, timeout=4)
-        return r.stdout.strip() if r.returncode == 0 else ""
-    except Exception:
-        return ""
-
-# Cheap transcript-tail parse (no LLM): last assistant text + tool names.
-# LED-1713: robust to thinking-tails — a mid-work session end often leaves only
-# thinking + tool_use in the last lines (no text block). Prefer the last text
-# block; fall back to the last thinking block ("[thinking] ") so the floor
-# handoff is never "(no final assistant text)". Widen (capped) to recover a
-# real text block pushed out of the immediate tail.
-final_text, final_thinking, tool_calls, turns = "", "", [], 0
-def _rc(o):
-    m = o.get("message") if isinstance(o, dict) else None
-    if isinstance(m, dict):
-        return (m.get("role", "") or (o.get("type", "") if isinstance(o, dict) else "")), m.get("content")
-    return (o.get("type", "") if isinstance(o, dict) else ""), (o.get("content") if isinstance(o, dict) else None)
-def _ex(content, sink):
-    tx, th = [], []
-    if isinstance(content, list):
-        for b in content:
-            if not isinstance(b, dict):
-                continue
-            bt = b.get("type")
-            if bt == "tool_use" and b.get("name") and sink is not None:
-                sink.append(str(b["name"]))
-            elif bt == "text" and b.get("text"):
-                tx.append(str(b["text"]))
-            elif bt == "thinking" and b.get("thinking"):
-                th.append(str(b["thinking"]))
-    elif isinstance(content, str):
-        tx.append(content)
-    return "\\n".join(tx).strip(), "\\n".join(th).strip()
-def _tail_text(path):
-    # Read only the trailing ~64KB (seek-from-end): transcripts can be MB and
-    # this is a time-boxed hook. Drop the partial first line when mid-file.
-    # Best-effort: fall back to a full read so correctness never regresses.
-    try:
-        with open(path, "rb") as fh:
-            fh.seek(0, os.SEEK_END)
-            size = fh.tell()
-            start = max(0, size - 65536)
-            fh.seek(start)
-            chunk = fh.read()
-        text = chunk.decode("utf-8", errors="replace")
-        if start > 0:
-            nl = text.find("\\n")
-            text = text[nl + 1:] if nl != -1 else ""
-        return text
-    except Exception:
-        return Path(path).read_text(errors="replace")
-try:
-    tl = [l for l in _tail_text(orphan).splitlines() if l.strip()]
-    tail = tl[-10:]
-    turns = len(tail)
-    for raw in tail:
-        try:
-            obj = json.loads(raw)
-        except Exception:
-            continue
-        role, content = _rc(obj)
-        tx, th = _ex(content, tool_calls)
-        if role == "assistant":
-            if tx:
-                final_text = tx
-            if th:
-                final_thinking = th
-    if not final_text and len(tl) > len(tail):
-        for raw in tl[-40:]:
-            try:
-                obj = json.loads(raw)
-            except Exception:
-                continue
-            role, content = _rc(obj)
-            if role != "assistant":
-                continue
-            tx, th = _ex(content, None)
-            if tx:
-                final_text = tx
-            if th:
-                final_thinking = th
-    if not final_text and final_thinking:
-        final_text = "[thinking] " + final_thinking
-except Exception:
-    pass
-
-if not turns:
-    sys.exit(0)
-
-branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
-status = run_git(["status", "--porcelain"])
-changed = [l[3:].strip() for l in status.splitlines() if l.strip()][:50] if status else []
-
-sessions = HOME / "sessions"
-sessions.mkdir(parents=True, exist_ok=True)
-sid = "session_" + time.strftime("%Y%m%d_%H%M%S")
-summary = ("[deterministic floor / orphaned] " + (final_text or "(no final assistant text)"))[:2000]
-key_decisions = []
-if tool_calls:
-    key_decisions.append("Last tool activity: " + ", ".join(tool_calls[-10:]))
-handoff = {
-    "id": sid,
-    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "venture": "all",
-    "summary": summary,
-    "items_completed": [],
-    "items_added": [],
-    "key_decisions": key_decisions,
-    "blockers": [],
-    "files_changed": changed,
-    "source": "deterministic",
-    "quality": "floor",
-    "git_branch": branch,
-    "salvaged_from": os.path.basename(orphan),
-}
-try:
-    (sessions / (sid + ".json")).write_text(json.dumps(handoff, indent=2))
-except Exception:
-    pass
-
-# Stamp so a second session start won't re-salvage the same orphan.
-try:
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text(json.dumps({
-        "ts": time.time(),
-        "iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "session_id": sid,
-        "source": "deterministic",
-        "quality": "floor",
-    }))
+    revived = {}
+    exact = result.get("salvaged_handoff") or {}
+    if ${autoReviveEnabled ? 'True' : 'False'}:
+        if exact.get("project_path") and exact.get("soul_id"):
+            revived = call(revive, {
+                "project_path": exact["project_path"],
+                "soul_id": exact["soul_id"],
+                "transcript_path": "",
+                "session_id": event.get("session_id", "") or "",
+                "chat_run_id": launcher_run,
+            })
+        elif status == "skipped":
+            # Safe legacy/repo-cwd fallback.  The backend refuses an unbound
+            # neutral portfolio cwd; there is no global-most-recent escape.
+            revived = call(revive, {
+                "project_path": "",
+                "transcript_path": "",
+                "session_id": event.get("session_id", "") or "",
+                "chat_run_id": launcher_run,
+            })
+    if str(revived.get("status", "")) in ("revived", "revived_scoped"):
+        context = revived.get("context", "")
+        if context:
+            print("  === Auto-revived working context (last soul) ===")
+            print(context)
+            # Two-phase delivery: never suppress a generation until its
+            # context bytes have successfully reached the hook's stdout.
+            # A crash before this flush may duplicate on retry, but cannot
+            # permanently lose an undelivered handoff.
+            sys.stdout.flush()
+            delivery_ack = revived.get("delivery_ack") or {}
+            if delivery_ack and callable(acknowledge_revival):
+                call(acknowledge_revival, delivery_ack)
 except Exception:
     pass
 PYEOF
-
-echo "  <"
-echo "  === Delimit Status ==="
-# Governance
-if [ -f "./delimit.yml" ] || [ -f "./.delimit/policies.yml" ]; then
-  echo "Governance: active | policy=project"
-elif [ -f "$DELIMIT_HOME/delimit.yml" ]; then
-  echo "Governance: active | policy=user"
-else
-  echo "Governance: not initialized -- run npx delimit-cli init"
 fi
-# Server + tools
-SERVER="$DELIMIT_HOME/server/ai/server.py"
-if [ -f "$SERVER" ]; then
-  TOOLS=$(grep -c '@mcp.tool' "$SERVER" 2>/dev/null || echo "0")
-  echo "Server: ready ($TOOLS tools)"
-else
-  echo "Server: not installed -- run npx delimit-cli setup"
-fi
-# Hooks + audit
-[ -f "${home}/.claude/settings.json" ] && grep -q '"hooks"' "${home}/.claude/settings.json" 2>/dev/null && HOOKS="enabled" || HOOKS="disabled"
-[ -d "$DELIMIT_HOME/audit" ] && AUDIT="on" || AUDIT="off"
-echo "Hooks: $HOOKS | Audit: $AUDIT"
-# MCP
-[ -f "${home}/.mcp.json" ] && grep -q "delimit" "${home}/.mcp.json" 2>/dev/null && echo "MCP: delimit registered" || echo "MCP: not registered"
-# Models
-MODELS=""
-[ -n "$XAI_API_KEY" ] && MODELS="\${MODELS}Grok + "
-[ -n "$GOOGLE_APPLICATION_CREDENTIALS" ] && MODELS="\${MODELS}Gemini + "
-[ -n "$OPENAI_API_KEY" ] && MODELS="\${MODELS}Codex + "
-[ -f "$DELIMIT_HOME/models.json" ] && MODELS=$(python3 -c "import json; d=json.load(open('$DELIMIT_HOME/models.json')); print(' + '.join(v.get('name',k) for k,v in d.items() if v.get('enabled')))" 2>/dev/null) || true
-[ -n "$MODELS" ] && echo "Deliberation: \${MODELS% + }"
-# Recent sessions (rolling window — orchestrator startup digest)
-# Subagent sessions get a scoped one-liner instead of the full digest, to
-# avoid pulling the orchestrator's multi-session context into a narrow task.
-SESSIONS="$DELIMIT_HOME/sessions"
-if [ "$DELIMIT_SESSION_TYPE" = "subagent" ] || [ "$DELIMIT_SESSION_TYPE" = "agent" ]; then
-  echo "Session: subagent (scoped) | handoff=\${DELIMIT_HANDOFF_ID:-none}"
-  echo "Revive scoped context with: delimit_revive(scope=\\"\${DELIMIT_HANDOFF_ID:-<handoff_id>}\\")"
-elif [ -d "$SESSIONS" ]; then
-  echo "Recent sessions (revive full state via delimit_revive + delimit_session_history):"
-  ls -t "$SESSIONS"/session_*.json 2>/dev/null | head -8 | while read -r f; do
-    python3 -c "import json; d=json.load(open('$f')); print('  - '+d.get('timestamp','?')[:10]+' '+d.get('summary','(no summary)')[:160])" 2>/dev/null
-  done
-fi
-${autoReviveBlock}
-${digestEchoBlock}
-# LED-1710: receiving-agent handoff post-flight. When a fresh session starts in a
-# git repo, re-validate the cross-agent handoff invariants the SENDING agent was
-# supposed to leave clean (junk identity / bare repo / stale index.lock / leaked
-# GIT_*). Read-only; surfaces only CRITICAL corruptions (so warn-level noise like
-# a stale capture stamp doesn't clutter every start). Time-boxed; never blocks.
-PF_BASE="$DELIMIT_HOME/server"
-if [ -f "$PF_BASE/ai/handoff_preflight.py" ] && [ -d "./.git" ]; then
-  PF_BASE="$PF_BASE" timeout 5 python3 - <<'PFEOF' 2>/dev/null || true
-import os, sys
-sys.path.insert(0, os.environ.get("PF_BASE", ""))
-try:
-    from ai.handoff_preflight import preflight_check
-    res = preflight_check(os.getcwd())
-except Exception:
-    sys.exit(0)
-bad = [c for c in res.get("checks", []) if c and not c.get("ok")]
-crit = [c for c in bad if c.get("severity") == "critical"]
-if crit:
-    print("Handoff post-flight: %d cross-agent issue(s) in this repo:" % len(crit))
-    for c in crit:
-        print("  ! %s: %s" % (c.get("name"), c.get("detail")))
-        if c.get("remediation"):
-            print("      fix: %s" % c.get("remediation"))
-PFEOF
-fi
-echo "  === Delimit Ready ==="
-# Note: shim governance works via PATH ordering ($HOME/.delimit/shims first).
-# We deliberately do NOT mv claude → claude-real or copy the shim into /usr/bin/claude.
-# That race-prone workaround caused "[Delimit] claude not found in PATH" failures
-# when npm reinstalls clobbered /usr/bin/claude mid-operation.
 `;
         fs.writeFileSync(hookScript, scriptContent);
         fs.chmodSync(hookScript, '755');
@@ -765,26 +523,77 @@ echo "  === Delimit Ready ==="
         if (!config.hooks.SessionStart) {
             config.hooks.SessionStart = [];
         }
-        // Check if identical hook already exists
-        const existingSession = config.hooks.SessionStart.find(group => {
-            const cmds = (group.hooks || []).map(h => h.command || '');
-            return cmds.some(c => c === hookScript);
-        });
-        if (!existingSession) {
-            // Remove any old delimit hooks (both script and npm command variants)
-            config.hooks.SessionStart = config.hooks.SessionStart.filter(group => {
-                const cmds = (group.hooks || []).map(h => h.command || '');
-                return !cmds.some(c => c.includes('delimit'));
+        const originalSessions = config.hooks.SessionStart;
+        const canonicalSession = {
+            matcher: '',
+            hooks: [{
+                type: 'command',
+                command: hookScript,
+                timeout: 20,
+            }],
+        };
+        const isDelimitSessionCommand = (command) => {
+            if (typeof command !== 'string') return false;
+            return command === hookScript
+                || /\bdelimit-cli\s+hook\s+session-start\b/.test(command);
+        };
+
+        // SessionStart hooks may run concurrently.  Normalize every Delimit
+        // delegate to one canonical group so two stale/duplicated entries
+        // cannot both select the same unacknowledged continuity generation.
+        // A mixed group is split so unrelated user hooks remain untouched.
+        const normalizedSessions = [];
+        let insertedCanonical = false;
+        for (const group of originalSessions) {
+            if (Array.isArray(group.hooks)) {
+                const retainedHooks = group.hooks.filter(
+                    hook => !isDelimitSessionCommand(hook.command),
+                );
+                if (retainedHooks.length !== group.hooks.length) {
+                    if (!insertedCanonical) {
+                        normalizedSessions.push(canonicalSession);
+                        insertedCanonical = true;
+                    }
+                    if (retainedHooks.length) {
+                        normalizedSessions.push({ ...group, hooks: retainedHooks });
+                    }
+                    continue;
+                }
+            } else if (isDelimitSessionCommand(group.command)) {
+                if (!insertedCanonical) {
+                    normalizedSessions.push(canonicalSession);
+                    insertedCanonical = true;
+                }
+                continue;
+            }
+            normalizedSessions.push(group);
+        }
+        if (!insertedCanonical) {
+            normalizedSessions.push(canonicalSession);
+        }
+
+        const originalJson = JSON.stringify(originalSessions);
+        const normalizedJson = JSON.stringify(normalizedSessions);
+        if (originalJson !== normalizedJson) {
+            // Preserve the existing diagnostic for the common timeout-only
+            // migration; duplicate/legacy normalization remains SessionStart.
+            const timeoutOnly = originalSessions.map(group => {
+                if (!Array.isArray(group.hooks)) return group;
+                return {
+                    ...group,
+                    hooks: group.hooks.map(hook => (
+                        hook.command === hookScript
+                            ? { ...hook, timeout: 20 }
+                            : hook
+                    )),
+                };
             });
-            config.hooks.SessionStart.push({
-                matcher: '',
-                hooks: [{
-                    type: 'command',
-                    command: hookScript,
-                    timeout: 10,
-                }],
-            });
-            changes.push('SessionStart');
+            config.hooks.SessionStart = normalizedSessions;
+            changes.push(
+                JSON.stringify(timeoutOnly) === normalizedJson
+                    ? 'SessionStart:timeout'
+                    : 'SessionStart',
+            );
         }
     }
 
@@ -906,240 +715,71 @@ echo "  === Delimit Ready ==="
         const hooksDir = path.join(home, '.claude', 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         const stopScript = path.join(hooksDir, 'delimit-stop');
-        const delimitHome = path.join(home, '.delimit');
+        // LED-4057: Stop is a provisional, project-bound upsert.  It performs
+        // no git or ledger mutation and never implements capture logic inline.
         const stopContent = '#!/bin/bash\n' + `
-# Delimit Stop — the > in </>
-# LED-1705: deterministic session-end capture floor.
-#
-# Claude Code passes the Stop event as JSON on stdin (includes
-# transcript_path). We:
-#   1. Preserve the existing ledger git push + timestamp behavior.
-#   2. If a fresh (<5 min) model-invoked capture exists, SKIP the floor so we
-#      don't clobber the richer artifact.
-#   3. Otherwise write a CHEAP deterministic floor handoff (git state +
-#      ledger context + transcript tail — NO LLM call) and stamp
-#      .last_capture so the next revive knows the session ended cleanly.
-# Must stay under the hook's 10s budget.
-
-DELIMIT_HOME="\${DELIMIT_HOME:-${delimitHome}}"
-LEDGER_DIR="$DELIMIT_HOME/ledger"
-
-# Capture stdin (Stop event JSON) so the python floor can read transcript_path.
+# Delimit Stop — thin Session Phoenix delegate.
+DELIMIT_HOME="\$DELIMIT_HOME"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$DELIMIT_NAMESPACE_ROOT"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$HOME/.delimit"
 STOP_EVENT_JSON="$(cat 2>/dev/null || true)"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DELIMIT_HOME/.last_session_end" 2>/dev/null || true
 
-# Push ledger changes so other models pick them up
-if [ -d "$LEDGER_DIR/.git" ]; then
-  cd "$LEDGER_DIR"
-  git add -A 2>/dev/null
-  git commit -m "session handoff $(date -u +%Y-%m-%dT%H:%M:%SZ)" --no-verify 2>/dev/null
-  git push origin main 2>/dev/null &
-fi
-
-# Save session timestamp (back-compat)
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DELIMIT_HOME/.last_session_end"
-
-# --- Deterministic capture floor (best-effort, time-boxed) ---
 CAPTURE_RESULT="$(DELIMIT_HOME="$DELIMIT_HOME" STOP_EVENT_JSON="$STOP_EVENT_JSON" \\
-  timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
-import json, os, sys, time, subprocess
+  DELIMIT_CHAT_RUN_ID="\${DELIMIT_CHAT_RUN_ID:-}" timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
+import inspect, json, os, sys
 from pathlib import Path
-
-HOME = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
-FRESH = 5 * 60
-stamp_path = HOME / ".last_capture"
-
-def read_stamp():
-    try:
-        return json.loads(stamp_path.read_text())
-    except Exception:
-        return None
-
-# Freshness gate: a fresh model capture wins — skip the floor.
-stamp = read_stamp()
-if stamp and stamp.get("source") == "model":
-    try:
-        if (time.time() - float(stamp.get("ts", 0))) <= FRESH:
-            print("skip:fresh-model-capture")
-            sys.exit(0)
-    except Exception:
-        pass
-
-# Parse the Stop event JSON for the transcript path.
-transcript_path = ""
+home = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
+server = str(home / "server")
+if not os.path.isdir(server):
+    sys.exit(0)
+sys.path.insert(0, server)
 try:
-    ev = json.loads(os.environ.get("STOP_EVENT_JSON", "") or "{}")
-    transcript_path = ev.get("transcript_path", "") or ""
+    from ai import session_phoenix as backend
+    if int(getattr(backend, "CONTINUITY_PROTOCOL_VERSION", 0)) < 2:
+        print("unavailable:backend-upgrade-required")
+        sys.exit(0)
+    capture_floor_from_transcript = backend.capture_floor_from_transcript
+    event = json.loads(os.environ.get("STOP_EVENT_JSON", "") or "{}")
+    proposed = {
+        "transcript_path": event.get("transcript_path", "") or "",
+        "project_path": "",
+        "source_model": "claude",
+        "session_id": event.get("session_id", "") or "",
+        "reason": event.get("reason", "stop") or "stop",
+        "chat_run_id": os.environ.get("DELIMIT_CHAT_RUN_ID", ""),
+        "trigger": "stop",
+        "finalize": False,
+    }
+    params = inspect.signature(capture_floor_from_transcript).parameters
+    # Older backends lack project-bound upsert identity. Fail closed instead of
+    # recreating cross-venture /root corruption through a compatibility call.
+    if not {"session_id", "trigger"}.issubset(params):
+        print("unavailable:backend-upgrade-required")
+        sys.exit(0)
+    result = capture_floor_from_transcript(
+        **{k: v for k, v in proposed.items() if k in params}
+    ) or {}
+    status = str(result.get("status", "error"))
+    ident = str(result.get("session_id") or result.get("soul_id") or "")
+    print(status + ":" + ident)
 except Exception:
-    pass
-
-def run_git(args):
-    try:
-        r = subprocess.run(["git"] + args, capture_output=True, text=True, timeout=4)
-        return r.stdout.strip() if r.returncode == 0 else ""
-    except Exception:
-        return ""
-
-branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
-status = run_git(["status", "--porcelain"])
-changed = [l[3:].strip() for l in status.splitlines() if l.strip()][:50] if status else []
-recent_commits = run_git(["log", "-3", "--oneline"]).splitlines() if branch else []
-
-# Cheap ledger context: newest few operations.jsonl summaries.
-ledger_items = []
-try:
-    ops = HOME / "ledger" / "operations.jsonl"
-    if ops.exists():
-        lines = [l for l in ops.read_text(errors="replace").splitlines() if l.strip()]
-        for raw in lines[-40:]:
-            try:
-                o = json.loads(raw)
-            except Exception:
-                continue
-            if o.get("type") == "update":
-                continue
-            t = o.get("title") or o.get("summary") or ""
-            if t:
-                ledger_items.append(t[:120])
-        ledger_items = ledger_items[-5:]
-except Exception:
-    pass
-
-# Transcript tail: last assistant text + tool-call names (no LLM).
-# LED-1713: robust to thinking-tails — prefer the last text block, fall back to
-# the last thinking block ("[thinking] ") so the floor is never empty, and
-# widen (capped) to recover a text block pushed out of the immediate tail.
-final_text, final_thinking, tool_calls, turns = "", "", [], 0
-def _rc(o):
-    m = o.get("message") if isinstance(o, dict) else None
-    if isinstance(m, dict):
-        return (m.get("role", "") or (o.get("type", "") if isinstance(o, dict) else "")), m.get("content")
-    return (o.get("type", "") if isinstance(o, dict) else ""), (o.get("content") if isinstance(o, dict) else None)
-def _ex(content, sink):
-    tx, th = [], []
-    if isinstance(content, list):
-        for b in content:
-            if not isinstance(b, dict):
-                continue
-            bt = b.get("type")
-            if bt == "tool_use" and b.get("name") and sink is not None:
-                sink.append(str(b["name"]))
-            elif bt == "text" and b.get("text"):
-                tx.append(str(b["text"]))
-            elif bt == "thinking" and b.get("thinking"):
-                th.append(str(b["thinking"]))
-    elif isinstance(content, str):
-        tx.append(content)
-    return "\\n".join(tx).strip(), "\\n".join(th).strip()
-def _tail_text(path):
-    # Read only the trailing ~64KB (seek-from-end): transcripts can be MB and
-    # this is a time-boxed hook. Drop the partial first line when mid-file.
-    # Best-effort: fall back to a full read so correctness never regresses.
-    try:
-        with open(path, "rb") as fh:
-            fh.seek(0, os.SEEK_END)
-            size = fh.tell()
-            start = max(0, size - 65536)
-            fh.seek(start)
-            chunk = fh.read()
-        text = chunk.decode("utf-8", errors="replace")
-        if start > 0:
-            nl = text.find("\\n")
-            text = text[nl + 1:] if nl != -1 else ""
-        return text
-    except Exception:
-        return Path(path).read_text(errors="replace")
-try:
-    if transcript_path and Path(transcript_path).exists():
-        tl = [l for l in _tail_text(transcript_path).splitlines() if l.strip()]
-        tail = tl[-10:]
-        turns = len(tail)
-        for raw in tail:
-            try:
-                obj = json.loads(raw)
-            except Exception:
-                continue
-            role, content = _rc(obj)
-            tx, th = _ex(content, tool_calls)
-            if role == "assistant":
-                if tx:
-                    final_text = tx
-                if th:
-                    final_thinking = th
-        if not final_text and len(tl) > len(tail):
-            for raw in tl[-40:]:
-                try:
-                    obj = json.loads(raw)
-                except Exception:
-                    continue
-                role, content = _rc(obj)
-                if role != "assistant":
-                    continue
-                tx, th = _ex(content, None)
-                if tx:
-                    final_text = tx
-                if th:
-                    final_thinking = th
-        if not final_text and final_thinking:
-            final_text = "[thinking] " + final_thinking
-except Exception:
-    pass
-
-# Write the floor handoff into the sessions dir (same shape as session_handoff).
-sessions = HOME / "sessions"
-sessions.mkdir(parents=True, exist_ok=True)
-sid = "session_" + time.strftime("%Y%m%d_%H%M%S")
-summary = ("[deterministic floor] " + (final_text or "(no final assistant text)"))[:2000]
-key_decisions = []
-if tool_calls:
-    key_decisions.append("Last tools: " + ", ".join(tool_calls[-10:]))
-if ledger_items:
-    key_decisions.append("Open ledger: " + " | ".join(ledger_items))
-if recent_commits:
-    key_decisions.append("Recent commits: " + " | ".join(recent_commits))
-handoff = {
-    "id": sid,
-    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "venture": "all",
-    "summary": summary,
-    "items_completed": [],
-    "items_added": [],
-    "key_decisions": key_decisions,
-    "blockers": [],
-    "files_changed": changed,
-    "source": "deterministic",
-    "quality": "floor",
-    "git_branch": branch,
-}
-try:
-    (sessions / (sid + ".json")).write_text(json.dumps(handoff, indent=2))
-except Exception:
-    pass
-
-# Stamp .last_capture so the next revive sees a clean exit.
-try:
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text(json.dumps({
-        "ts": time.time(),
-        "iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "session_id": sid,
-        "source": "deterministic",
-        "quality": "floor",
-    }))
-except Exception:
-    pass
-
-print("floor:" + sid)
+    print("error:capture-unavailable")
 PYEOF
 )"
 
 echo ""
 echo "  />"
 case "$CAPTURE_RESULT" in
-  skip:*)  echo "  Fresh capture already saved this session — floor skipped." ;;
-  floor:*) echo "  Deterministic session floor captured (git + ledger + transcript tail)." ;;
-  *)       echo "  Session timestamp saved (floor capture unavailable)." ;;
+  captured:*|updated:*|deduplicated:*|finalized:*|already_captured:*|noop:*)
+    echo "  Project-bound session floor saved." ;;
+  ambiguous:*|blocked_ambiguity:*)
+    echo "  Continuity ambiguity detected; no venture floor was written." ;;
+  *)
+    echo "  Session ended; project-bound floor capture was unavailable." ;;
 esac
 echo ""
+exit 0
 `;
         fs.writeFileSync(stopScript, stopContent);
         fs.chmodSync(stopScript, '755');
@@ -1191,211 +831,48 @@ echo ""
         const hooksDir = path.join(home, '.claude', 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         const sessionEndScript = path.join(hooksDir, 'delimit-session-end');
-        const delimitHome = path.join(home, '.delimit');
+        // LED-4057: SessionEnd finalizes the same backend-owned logical
+        // session artifact Stop provisionally upserted.  No inherited-cwd git,
+        // global ledger read, timestamp-id append, or inline floor writer.
         const sessionEndContent = '#!/bin/bash\n' + `
-# Delimit SessionEnd — the guaranteed > in </> on real session exit.
-#
-# Claude Code fires SessionEnd on /exit, logout, window close, or clear, and
-# passes the event as JSON on stdin (session_id, transcript_path, reason). The
-# Stop hook only fires at end-of-TURN, so it can miss a hard exit; SessionEnd is
-# the safety net that guarantees an end-of-session floor handoff exists.
-#
-# This is a DETERMINISTIC, NO-LLM, time-boxed (<10s) capture:
-#   * git state (branch + porcelain changes + recent commits)
-#   * cheap ledger context (newest operations.jsonl summaries)
-#   * transcript tail (last assistant text + tool names — NO model call)
-# It writes a session soul FLOOR into ~/.delimit/sessions and stamps
-# .last_capture so the next session's delimit_revive sees a clean exit.
-# A rich LLM soul still needs the model (delimit_soul_capture); this floor is
-# the automatic baseline. Best-effort — ALWAYS exits 0, never blocks exit.
-
-DELIMIT_HOME="\${DELIMIT_HOME:-${delimitHome}}"
-
-# Capture stdin (SessionEnd event JSON) so the python floor can read transcript_path.
+# Delimit SessionEnd — thin Session Phoenix finalizer.
+DELIMIT_HOME="\$DELIMIT_HOME"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$DELIMIT_NAMESPACE_ROOT"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$HOME/.delimit"
 SESSIONEND_EVENT_JSON="$(cat 2>/dev/null || true)"
-
-# Save session timestamp (back-compat, mirrors the Stop hook).
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DELIMIT_HOME/.last_session_end" 2>/dev/null || true
 
 DELIMIT_HOME="$DELIMIT_HOME" SESSIONEND_EVENT_JSON="$SESSIONEND_EVENT_JSON" \\
-  timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
-import json, os, sys, time, subprocess
+  DELIMIT_CHAT_RUN_ID="\${DELIMIT_CHAT_RUN_ID:-}" timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
+import inspect, json, os, sys
 from pathlib import Path
-
-HOME = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
-FRESH = 5 * 60
-stamp_path = HOME / ".last_capture"
-
-# Freshness gate: a fresh MODEL capture (a rich soul the user explicitly made)
-# wins — never clobber it with a floor. A prior deterministic floor does NOT
-# block us: SessionEnd should record the true end-of-session state.
+home = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
+server = str(home / "server")
+if not os.path.isdir(server):
+    sys.exit(0)
+sys.path.insert(0, server)
 try:
-    stamp = json.loads(stamp_path.read_text())
-    if stamp.get("source") == "model" and (time.time() - float(stamp.get("ts", 0))) <= FRESH:
+    from ai import session_phoenix as backend
+    if int(getattr(backend, "CONTINUITY_PROTOCOL_VERSION", 0)) < 2:
         sys.exit(0)
-except Exception:
-    pass
-
-# Parse the SessionEnd event JSON for the transcript path.
-transcript_path = ""
-try:
-    ev = json.loads(os.environ.get("SESSIONEND_EVENT_JSON", "") or "{}")
-    transcript_path = ev.get("transcript_path", "") or ""
-except Exception:
-    pass
-
-def run_git(args):
-    try:
-        r = subprocess.run(["git"] + args, capture_output=True, text=True, timeout=4)
-        return r.stdout.strip() if r.returncode == 0 else ""
-    except Exception:
-        return ""
-
-branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
-status = run_git(["status", "--porcelain"])
-changed = [l[3:].strip() for l in status.splitlines() if l.strip()][:50] if status else []
-recent_commits = run_git(["log", "-3", "--oneline"]).splitlines() if branch else []
-
-# Cheap ledger context: newest few operations.jsonl summaries.
-ledger_items = []
-try:
-    ops = HOME / "ledger" / "operations.jsonl"
-    if ops.exists():
-        lines = [l for l in ops.read_text(errors="replace").splitlines() if l.strip()]
-        for raw in lines[-40:]:
-            try:
-                o = json.loads(raw)
-            except Exception:
-                continue
-            if o.get("type") == "update":
-                continue
-            t = o.get("title") or o.get("summary") or ""
-            if t:
-                ledger_items.append(t[:120])
-        ledger_items = ledger_items[-5:]
-except Exception:
-    pass
-
-# Transcript tail: last assistant text + tool-call names (no LLM). Robust to
-# thinking-tails — prefer the last text block, fall back to the last thinking
-# block ("[thinking] ") so the floor is never empty; widen (capped) to recover
-# a text block pushed out of the immediate tail. Reads only the trailing ~64KB.
-final_text, final_thinking, tool_calls, turns = "", "", [], 0
-def _rc(o):
-    m = o.get("message") if isinstance(o, dict) else None
-    if isinstance(m, dict):
-        return (m.get("role", "") or (o.get("type", "") if isinstance(o, dict) else "")), m.get("content")
-    return (o.get("type", "") if isinstance(o, dict) else ""), (o.get("content") if isinstance(o, dict) else None)
-def _ex(content, sink):
-    tx, th = [], []
-    if isinstance(content, list):
-        for b in content:
-            if not isinstance(b, dict):
-                continue
-            bt = b.get("type")
-            if bt == "tool_use" and b.get("name") and sink is not None:
-                sink.append(str(b["name"]))
-            elif bt == "text" and b.get("text"):
-                tx.append(str(b["text"]))
-            elif bt == "thinking" and b.get("thinking"):
-                th.append(str(b["thinking"]))
-    elif isinstance(content, str):
-        tx.append(content)
-    return "\\n".join(tx).strip(), "\\n".join(th).strip()
-def _tail_text(path):
-    try:
-        with open(path, "rb") as fh:
-            fh.seek(0, os.SEEK_END)
-            size = fh.tell()
-            start = max(0, size - 65536)
-            fh.seek(start)
-            chunk = fh.read()
-        text = chunk.decode("utf-8", errors="replace")
-        if start > 0:
-            nl = text.find("\\n")
-            text = text[nl + 1:] if nl != -1 else ""
-        return text
-    except Exception:
-        return Path(path).read_text(errors="replace")
-try:
-    if transcript_path and Path(transcript_path).exists():
-        tl = [l for l in _tail_text(transcript_path).splitlines() if l.strip()]
-        tail = tl[-10:]
-        turns = len(tail)
-        for raw in tail:
-            try:
-                obj = json.loads(raw)
-            except Exception:
-                continue
-            role, content = _rc(obj)
-            tx, th = _ex(content, tool_calls)
-            if role == "assistant":
-                if tx:
-                    final_text = tx
-                if th:
-                    final_thinking = th
-        if not final_text and len(tl) > len(tail):
-            for raw in tl[-40:]:
-                try:
-                    obj = json.loads(raw)
-                except Exception:
-                    continue
-                role, content = _rc(obj)
-                if role != "assistant":
-                    continue
-                tx, th = _ex(content, None)
-                if tx:
-                    final_text = tx
-                if th:
-                    final_thinking = th
-        if not final_text and final_thinking:
-            final_text = "[thinking] " + final_thinking
-except Exception:
-    pass
-
-# Write the floor handoff into the sessions dir (same shape as session_handoff).
-sessions = HOME / "sessions"
-sessions.mkdir(parents=True, exist_ok=True)
-sid = "session_" + time.strftime("%Y%m%d_%H%M%S")
-summary = ("[deterministic floor / session-end] " + (final_text or "(no final assistant text)"))[:2000]
-key_decisions = []
-if tool_calls:
-    key_decisions.append("Last tools: " + ", ".join(tool_calls[-10:]))
-if ledger_items:
-    key_decisions.append("Open ledger: " + " | ".join(ledger_items))
-if recent_commits:
-    key_decisions.append("Recent commits: " + " | ".join(recent_commits))
-handoff = {
-    "id": sid,
-    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "venture": "all",
-    "summary": summary,
-    "items_completed": [],
-    "items_added": [],
-    "key_decisions": key_decisions,
-    "blockers": [],
-    "files_changed": changed,
-    "source": "deterministic",
-    "quality": "floor",
-    "git_branch": branch,
-    "trigger": "session-end",
-}
-try:
-    (sessions / (sid + ".json")).write_text(json.dumps(handoff, indent=2))
-except Exception:
-    pass
-
-# Stamp .last_capture so the next revive sees a clean exit.
-try:
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text(json.dumps({
-        "ts": time.time(),
-        "iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "session_id": sid,
-        "source": "deterministic",
-        "quality": "floor",
+    capture_floor_from_transcript = backend.capture_floor_from_transcript
+    event = json.loads(os.environ.get("SESSIONEND_EVENT_JSON", "") or "{}")
+    proposed = {
+        "transcript_path": event.get("transcript_path", "") or "",
+        "project_path": "",
+        "source_model": "claude",
+        "session_id": event.get("session_id", "") or "",
+        "reason": event.get("reason", "session-end") or "session-end",
+        "chat_run_id": os.environ.get("DELIMIT_CHAT_RUN_ID", ""),
         "trigger": "session-end",
-    }))
+        "finalize": True,
+    }
+    params = inspect.signature(capture_floor_from_transcript).parameters
+    if not {"session_id", "trigger"}.issubset(params):
+        sys.exit(0)
+    capture_floor_from_transcript(
+        **{k: v for k, v in proposed.items() if k in params}
+    )
 except Exception:
     pass
 PYEOF
@@ -1439,7 +916,6 @@ exit 0
         const hooksDir = path.join(home, '.claude', 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         const recorderScript = path.join(hooksDir, 'delimit-agent-record');
-        const delimitHome = path.join(home, '.delimit');
         const recorderContent = '#!/bin/bash\n' + `
 # Delimit PostToolUse flight-recorder (STR-2202 — HOOK half of "tools fire tools").
 #
@@ -1454,7 +930,9 @@ exit 0
 # The record carries {model, task_type, outcome, venture} so delegated-work
 # outcomes feed the LED-3720 instrumentation. Best-effort, time-boxed, ALWAYS
 # exits 0 — a recorder must never disrupt the tool it observes.
-DELIMIT_HOME="\${DELIMIT_HOME:-${delimitHome}}"
+DELIMIT_HOME="\$DELIMIT_HOME"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$DELIMIT_NAMESPACE_ROOT"
+[ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$HOME/.delimit"
 EVENT_JSON="$(cat 2>/dev/null || true)"
 
 DELIMIT_HOME="$DELIMIT_HOME" EVENT_JSON="$EVENT_JSON" \\
@@ -2102,7 +1580,7 @@ async function hookSessionStart() {
     lines.push('=== Delimit Status ===');
 
     const home = getHome();
-    const delimitHome = path.join(home, '.delimit');
+    const delimitHome = getDelimitHome();
     const cwd = process.cwd();
 
     // Governance status + policy source

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -435,6 +435,71 @@ DELIMIT_HOME="\$DELIMIT_HOME"
 [ -n "\$DELIMIT_HOME" ] || DELIMIT_HOME="\$HOME/.delimit"
 SESSIONSTART_EVENT_JSON="\$(cat 2>/dev/null || true)"
 
+echo "  === Delimit Status ==="
+# Preserve the pre-existing, read-only startup diagnostics while delegating
+# continuity to Session Phoenix. These checks are intentionally before the
+# final continuity delivery/acknowledgement phase.
+if [ -f "./delimit.yml" ] || [ -f "./.delimit/policies.yml" ]; then
+  echo "Governance: active | policy=project"
+elif [ -f "$DELIMIT_HOME/delimit.yml" ]; then
+  echo "Governance: active | policy=user"
+else
+  echo "Governance: not initialized -- run npx delimit-cli init"
+fi
+SERVER="$DELIMIT_HOME/server/ai/server.py"
+if [ -f "$SERVER" ]; then
+  TOOLS=\$(grep -c '@mcp.tool' "$SERVER" 2>/dev/null || echo "0")
+  echo "Server: ready ($TOOLS tools)"
+else
+  echo "Server: not installed -- run npx delimit-cli setup"
+fi
+[ -f "${home}/.claude/settings.json" ] && grep -q '"hooks"' "${home}/.claude/settings.json" 2>/dev/null && HOOKS="enabled" || HOOKS="disabled"
+[ -d "$DELIMIT_HOME/audit" ] && AUDIT="on" || AUDIT="off"
+echo "Hooks: $HOOKS | Audit: $AUDIT"
+[ -f "${home}/.mcp.json" ] && grep -q "delimit" "${home}/.mcp.json" 2>/dev/null && echo "MCP: delimit registered" || echo "MCP: not registered"
+MODELS=""
+[ -n "$XAI_API_KEY" ] && MODELS="\${MODELS}Grok + "
+[ -n "$GOOGLE_APPLICATION_CREDENTIALS" ] && MODELS="\${MODELS}Gemini + "
+[ -n "$OPENAI_API_KEY" ] && MODELS="\${MODELS}Codex + "
+[ -f "$DELIMIT_HOME/models.json" ] && MODELS=\$(python3 -c "import json; d=json.load(open('$DELIMIT_HOME/models.json')); print(' + '.join(v.get('name',k) for k,v in d.items() if isinstance(v,dict) and v.get('enabled')))" 2>/dev/null) || true
+[ -n "$MODELS" ] && echo "Deliberation: \${MODELS% + }"
+
+# Preserve the rolling session index for operators. This is metadata only;
+# actual continuity selection remains project-bound in Session Phoenix below.
+SESSIONS="$DELIMIT_HOME/sessions"
+if [ "$DELIMIT_SESSION_TYPE" = "subagent" ] || [ "$DELIMIT_SESSION_TYPE" = "agent" ]; then
+  echo "Session: subagent (scoped) | handoff=\${DELIMIT_HANDOFF_ID:-none}"
+  echo "Revive scoped context with: delimit_revive(scope=\"\${DELIMIT_HANDOFF_ID:-<handoff_id>}\")"
+elif [ -d "$SESSIONS" ]; then
+  echo "Recent sessions (revive full state via delimit_revive + delimit_session_history):"
+  ls -t "$SESSIONS"/session_*.json 2>/dev/null | head -8 | while read -r f; do
+    python3 -c "import json; d=json.load(open('$f')); print('  - '+d.get('timestamp','?')[:10]+' '+d.get('summary','(no summary)')[:160])" 2>/dev/null
+  done
+fi
+
+# Preserve the receiving-agent handoff post-flight. It is read-only,
+# time-boxed, and surfaces only critical repository corruption.
+PF_BASE="$DELIMIT_HOME/server"
+if [ -f "$PF_BASE/ai/handoff_preflight.py" ] && [ -d "./.git" ]; then
+  PF_BASE="$PF_BASE" timeout 5 python3 - <<'PFEOF' 2>/dev/null || true
+import os, sys
+sys.path.insert(0, os.environ.get("PF_BASE", ""))
+try:
+    from ai.handoff_preflight import preflight_check
+    res = preflight_check(os.getcwd())
+except Exception:
+    sys.exit(0)
+bad = [c for c in res.get("checks", []) if c and not c.get("ok")]
+crit = [c for c in bad if c.get("severity") == "critical"]
+if crit:
+    print("Handoff post-flight: %d cross-agent issue(s) in this repo:" % len(crit))
+    for c in crit:
+        print("  ! %s: %s" % (c.get("name"), c.get("detail")))
+        if c.get("remediation"):
+            print("      fix: %s" % c.get("remediation"))
+PFEOF
+fi
+
 ${digestEchoBlock}
 echo "  === Delimit Ready ==="
 
@@ -988,10 +1053,15 @@ result_text = result_text[:2000]
 def _resolve_venture(cwd):
     # LED-4244: a NEUTRAL cwd (portfolio roots like /root, /home/<user>, /)
     # must not become the venture name. Prefer the active-venture registry
-    # maintained by the CLI resolver (~/.delimit/active_venture.json);
+    # maintained by the CLI resolver (<active namespace>/active_venture.json);
     # fall back to the cwd basename; "all" only when nothing resolves.
     base = os.path.basename(cwd.rstrip("/")) or ""
     home = os.path.expanduser("~")
+    delimit_root = (
+        os.environ.get("DELIMIT_HOME")
+        or os.environ.get("DELIMIT_NAMESPACE_ROOT")
+        or os.path.join(home, ".delimit")
+    )
     neutral = (
         not base
         or cwd.rstrip("/") in ("", "/", home)
@@ -999,7 +1069,7 @@ def _resolve_venture(cwd):
     )
     if neutral:
         try:
-            with open(os.path.join(home, ".delimit", "active_venture.json")) as fh:
+            with open(os.path.join(delimit_root, "active_venture.json")) as fh:
                 reg = json.load(fh)
             v = str((reg or {}).get("venture") or "").strip()
             if v:

--- a/tests/chat-repl-continuity.test.js
+++ b/tests/chat-repl-continuity.test.js
@@ -1,79 +1,267 @@
 'use strict';
 
-// LED-1962: `delimit chat` cross-agent continuity.
-//
-// Two fixes, guarded here at the source + wiring level (the interactive launch
-// loop and the python-spawning helpers can't be unit-run in CI without a live
-// gateway + polluting ~/.delimit/souls, so we assert the load-bearing shape and
-// rely on the documented runtime verification for behavior):
-//   Fix 1  reviveSoulForLaunch injects the revived CURRENT-project soul into
-//          codex's launch prompt (codex has no session-start hook; claude is
-//          excluded because its SessionStart hook already injects).
-//   Fix 2  captureSoulForMigration salvages the dying session's REAL transcript
-//          via reconcile_orphan instead of writing a thin "migration from X"
-//          soul that both shadowed context and blocked the next reconcile.
-
-const { test, describe } = require('node:test');
+const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const { DelimitChatREPL } = require('../lib/chat-repl');
-const SRC = fs.readFileSync(path.join(__dirname, '..', 'lib', 'chat-repl.js'), 'utf-8');
 
-describe('LED-1962 delimit chat cross-agent continuity', () => {
-    test('exposes the continuity helpers on the REPL', () => {
-        const repl = new DelimitChatREPL({});
-        assert.strictEqual(typeof repl.reviveSoulForLaunch, 'function',
-            'reviveSoulForLaunch is wired');
-        assert.strictEqual(typeof repl.captureSoulForMigration, 'function',
-            'captureSoulForMigration is wired');
+describe('LED-4057 delimit chat project-bound continuity', () => {
+    let backendRoot;
+
+    beforeEach(() => {
+        backendRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-phoenix-'));
+        fs.mkdirSync(path.join(backendRoot, 'ai'), { recursive: true });
+        fs.writeFileSync(path.join(backendRoot, 'ai', 'session_phoenix.py'), '# fixture\n');
     });
 
-    // --- Fix 2: rich migration capture ---------------------------------------
-    test('captureSoulForMigration salvages via reconcile_orphan, not a thin marker', () => {
-        // The dying session's transcript is salvaged (rich) instead of writing a
-        // thin "Auto-Phoenix migration from X" soul.
-        assert.ok(/reconcile_orphan/.test(SRC),
-            'migration capture calls reconcile_orphan');
-        // The thin capture_soul(active_task="Auto-Phoenix migration…") is now only
-        // a FALLBACK (guarded by the "nothing salvageable" branch), never the
-        // default. Guard: it must be preceded by the reconcile decision.
-        const migrationIdx = SRC.indexOf('Auto-Phoenix migration from');
-        const reconcileIdx = SRC.indexOf('reconcile_orphan');
-        assert.ok(reconcileIdx !== -1 && reconcileIdx < migrationIdx,
-            'reconcile_orphan runs before the thin fallback');
-        // The fresh-capture guard: never clobber a soul the model already wrote.
-        assert.ok(/last_capture_present/.test(SRC),
-            'respects the .last_capture guard (no clobber of a fresh rich soul)');
+    afterEach(() => {
+        fs.rmSync(backendRoot, { recursive: true, force: true });
     });
 
-    // --- Fix 1: codex soul injection -----------------------------------------
-    test('injects the revived soul into codex launch, but NOT claude', () => {
-        // Codex has no injection hook -> chat injects the soul as its prompt.
-        assert.ok(/activeModel\.id === 'codex'/.test(SRC),
-            'codex launch is special-cased for soul injection');
-        assert.ok(/reviveSoulForLaunch\(\)/.test(SRC),
-            'the codex path revives a soul to inject');
-        assert.ok(/Auto-revived session context/.test(SRC),
-            'the injected prompt is clearly labeled as revived context');
-        // Claude must NOT be injected here (it revives via its SessionStart hook;
-        // double-injection would just bloat context). There is no
-        // `activeModel.id === 'claude'` soul-injection branch.
-        assert.ok(!/activeModel\.id === 'claude'[\s\S]{0,120}reviveSoulForLaunch/.test(SRC),
-            'claude is not double-injected');
+    function replReturning(payload, options = {}) {
+        const calls = [];
+        const repl = new DelimitChatREPL({
+            chatRunId: 'run-led-4057',
+            sessionPhoenixRoot: backendRoot,
+            spawnSync: (command, args, spawnOptions) => {
+                calls.push({ command, args, spawnOptions });
+                return {
+                    status: 0,
+                    stdout: JSON.stringify(payload) + '\n',
+                    stderr: '',
+                };
+            },
+            ...options,
+        });
+        return { repl, calls };
+    }
+
+    test('one stable chatRunId is reused by capture, revive, and child env', () => {
+        const { repl, calls } = replReturning({ status: 'captured', soul_id: 's1' });
+
+        const capture = repl.captureSoulForMigration(
+            'claude',
+            'codex',
+            { trigger: 'launcher-failure', reason: 'exit-1' },
+        );
+        assert.strictEqual(capture.status, 'captured');
+
+        const sent = JSON.parse(calls[0].args[2]);
+        assert.strictEqual(sent.chat_run_id, 'run-led-4057');
+        assert.strictEqual(sent.source_model, 'claude');
+        assert.strictEqual(sent.to_model, 'codex');
+        assert.strictEqual(sent.trigger, 'launcher-failure');
+        assert.strictEqual(sent.reason, 'exit-1');
+        assert.strictEqual(calls[0].spawnOptions.env.DELIMIT_CHAT_RUN_ID, 'run-led-4057');
+
+        repl.reviveSoulForLaunch();
+        const revivePayload = JSON.parse(calls[1].args[2]);
+        assert.strictEqual(revivePayload.chat_run_id, 'run-led-4057');
+        assert.strictEqual(revivePayload.allow_global_fallback, false);
+        assert.strictEqual(repl.chatRunId, 'run-led-4057');
     });
 
-    test('reviveSoulForLaunch is CURRENT-project only (no cross-venture global scan)', () => {
-        // `delimit chat` switches models in the same cwd, so the revive is scoped
-        // to the current project (get_latest_soul with no arg = cwd). It must NOT
-        // pull find_most_recent_soul_across_projects, which would risk injecting a
-        // different venture's soul into this session.
-        const fnStart = SRC.indexOf('reviveSoulForLaunch()');
-        const fnBody = SRC.slice(fnStart, fnStart + 900);
-        assert.ok(/get_latest_soul\(\)/.test(fnBody),
-            'reviveSoulForLaunch uses the current-project soul');
-        assert.ok(!/find_most_recent_soul_across_projects/.test(fnBody),
-            'reviveSoulForLaunch does NOT do a cross-project global scan');
+    test('capture success is based on structured backend status, not process exit', () => {
+        for (const status of ['captured', 'updated', 'deduplicated', 'finalized', 'already_captured', 'noop']) {
+            const { repl } = replReturning({ status });
+            assert.strictEqual(repl.captureSucceeded(repl.captureSoulForMigration('claude')), true);
+        }
+
+        for (const status of ['ambiguous', 'blocked_ambiguity', 'unavailable', 'error', 'skipped']) {
+            const { repl } = replReturning({ status });
+            assert.strictEqual(repl.captureSucceeded(repl.captureSoulForMigration('claude')), false);
+        }
+    });
+
+    test('revive returns ambiguity without converting it into injectable context', () => {
+        const { repl } = replReturning({
+            status: 'ambiguous',
+            candidates: ['delimit-mcp', 'wire-report'],
+            context: 'must not inject',
+        });
+        const result = repl.reviveSoulForLaunch();
+        assert.strictEqual(result.status, 'ambiguous');
+        assert.deepStrictEqual(result.candidates, ['delimit-mcp', 'wire-report']);
+        assert.strictEqual(repl.captureSucceeded(result), false);
+        assert.strictEqual(
+            repl.formatContinuityCandidates([
+                { venture: 'delimit-mcp', project_path: '/home/delimit/delimit-gateway' },
+                { name: 'Wire Report', project_path: '/home/jamsons/ventures/wire-report' },
+            ]),
+            'delimit-mcp, Wire Report',
+        );
+    });
+
+    test('a Codex revival is acknowledged only after confirmed delivery', () => {
+        let acknowledged = false;
+        const calls = [];
+        const repl = new DelimitChatREPL({
+            chatRunId: 'run-led-4057',
+            sessionPhoenixRoot: backendRoot,
+            spawnSync: (command, args) => {
+                const functionName = args[1].match(
+                    /getattr\(backend, "([^"]+)", None\)/,
+                )?.[1];
+                calls.push(functionName);
+                if (functionName === 'revive') {
+                    return {
+                        status: 0,
+                        stdout: JSON.stringify(
+                            acknowledged
+                                ? { status: 'no_active_project' }
+                                : {
+                                    status: 'revived',
+                                    context: 'EXACT CODEX CONTEXT',
+                                    delivery_ack: {
+                                        capture_key: 'capture-1',
+                                        write_id: 'generation-1',
+                                        transcript_path: '/portfolio/session.jsonl',
+                                        logical_session_id: 'logical-1',
+                                        launcher_run_id: 'run-led-4057',
+                                    },
+                                },
+                        ) + '\n',
+                    };
+                }
+                if (functionName === 'acknowledge_revival') {
+                    acknowledged = true;
+                    return {
+                        status: 0,
+                        stdout: '{"status":"acknowledged"}\n',
+                    };
+                }
+                throw new Error(`unexpected backend function: ${functionName}`);
+            },
+        });
+
+        const delivered = repl.reviveSoulForLaunch();
+        assert.strictEqual(delivered.status, 'revived');
+        assert.strictEqual(
+            repl.acknowledgeCodexRevival(delivered, { status: 0 }).status,
+            'acknowledged',
+        );
+        assert.strictEqual(
+            repl.reviveSoulForLaunch().status,
+            'no_active_project',
+            'an acknowledged generation is not reinjected',
+        );
+        assert.deepStrictEqual(calls, [
+            'revive',
+            'acknowledge_revival',
+            'revive',
+        ]);
+    });
+
+    test('a failed or aborted Codex delivery remains retryable', () => {
+        for (const childResult of [
+            { status: 1 },
+            { status: null, signal: 'SIGINT' },
+            { status: null, error: new Error('spawn failed') },
+        ]) {
+            let acknowledgeCalls = 0;
+            const repl = new DelimitChatREPL({
+                chatRunId: 'run-led-4057',
+                sessionPhoenixRoot: backendRoot,
+                spawnSync: (command, args) => {
+                    const functionName = args[1].match(
+                        /getattr\(backend, "([^"]+)", None\)/,
+                    )?.[1];
+                    if (functionName === 'acknowledge_revival') {
+                        acknowledgeCalls += 1;
+                    }
+                    return {
+                        status: 0,
+                        stdout: JSON.stringify({
+                            status: 'revived',
+                            context: 'RETRYABLE CODEX CONTEXT',
+                            delivery_ack: {
+                                capture_key: 'capture-2',
+                                write_id: 'generation-2',
+                            },
+                        }) + '\n',
+                    };
+                },
+            });
+
+            const first = repl.reviveSoulForLaunch();
+            assert.strictEqual(
+                repl.acknowledgeCodexRevival(first, childResult).status,
+                'retryable',
+            );
+            assert.strictEqual(acknowledgeCalls, 0);
+            assert.strictEqual(
+                repl.reviveSoulForLaunch().status,
+                'revived',
+                'an unacknowledged generation stays eligible for retry',
+            );
+        }
+    });
+
+    test('backend absence and malformed output fail closed', () => {
+        const missing = new DelimitChatREPL({
+            chatRunId: 'run-led-4057',
+            sessionPhoenixRoot: path.join(backendRoot, 'missing'),
+            spawnSync: () => { throw new Error('must not spawn'); },
+        });
+        assert.deepStrictEqual(
+            missing.captureSoulForMigration('claude'),
+            { status: 'unavailable', reason: 'backend_missing' },
+        );
+
+        const malformed = replReturning({ status: 'captured' });
+        malformed.repl._spawnSync = () => ({ status: 0, stdout: 'not-json\n', stderr: '' });
+        assert.deepStrictEqual(
+            malformed.repl.captureSoulForMigration('claude'),
+            { status: 'unavailable', reason: 'backend_call_failed' },
+        );
+    });
+
+    test('namespace-only installs resolve Session Phoenix from that namespace', () => {
+        const savedHome = process.env.DELIMIT_HOME;
+        const savedNamespace = process.env.DELIMIT_NAMESPACE_ROOT;
+        const namespacedServer = path.join(backendRoot, 'server', 'ai');
+        fs.mkdirSync(namespacedServer, { recursive: true });
+        fs.writeFileSync(
+            path.join(namespacedServer, 'session_phoenix.py'),
+            'CONTINUITY_PROTOCOL_VERSION = 2\n',
+        );
+        try {
+            delete process.env.DELIMIT_HOME;
+            process.env.DELIMIT_NAMESPACE_ROOT = backendRoot;
+            const repl = new DelimitChatREPL({
+                chatRunId: 'namespace-run',
+                spawnSync: () => ({
+                    status: 0,
+                    stdout: '{"status":"noop"}\n',
+                    stderr: '',
+                }),
+            });
+            assert.strictEqual(
+                repl.sessionPhoenixRoot,
+                path.join(backendRoot, 'server'),
+            );
+        } finally {
+            if (savedHome === undefined) delete process.env.DELIMIT_HOME;
+            else process.env.DELIMIT_HOME = savedHome;
+            if (savedNamespace === undefined) delete process.env.DELIMIT_NAMESPACE_ROOT;
+            else process.env.DELIMIT_NAMESPACE_ROOT = savedNamespace;
+        }
+    });
+
+    test('clean-exit request carries finalize intent but no guessed transcript', () => {
+        const { repl, calls } = replReturning({ status: 'unavailable', reason: 'no_bound_session' });
+        const result = repl.captureSoulForMigration(
+            'codex',
+            '',
+            { trigger: 'launcher-clean-exit', reason: 'clean-exit', finalize: true },
+        );
+        const payload = JSON.parse(calls[0].args[2]);
+        assert.strictEqual(payload.finalize, true);
+        assert.strictEqual(payload.trigger, 'launcher-clean-exit');
+        assert.strictEqual(payload.transcript_path, '');
+        assert.strictEqual(repl.captureSucceeded(result), false);
     });
 });

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -1323,6 +1323,53 @@ describe('STR-2202 subagent flight-recorder (PostToolUse)', () => {
         assert.ok(s.includes('tasks.json'), 'has direct-write fallback');
     });
 
+    it('resolves neutral-cwd venture via the active-venture registry (LED-4244)', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true });
+
+        const recorderPath = path.join(claudeDir, 'hooks', 'delimit-agent-record');
+        const s = fs.readFileSync(recorderPath, 'utf-8');
+        // The bare basename assignment is gone; the resolver consults the
+        // registry the CLI maintains (LED-4057 acceptance follow-up).
+        assert.ok(s.includes('_resolve_venture'), 'resolver function present');
+        assert.ok(s.includes('active_venture.json'), 'registry consulted');
+        assert.ok(!s.includes('venture = os.path.basename'), 'bare basename assignment removed');
+
+        // Behavioral matrix: execute the generated resolver under a fake HOME.
+        const m = s.match(/def _resolve_venture[\s\S]*?\n\nventure = _resolve_venture\(cwd\)/);
+        assert.ok(m, 'resolver block extractable from generated script');
+        const pySnippet = m[0].replace(/\n\nventure = _resolve_venture\(cwd\)\s*$/, '');
+
+        const regHome = path.join(tmpDir, 'home-with-registry');
+        fs.mkdirSync(path.join(regHome, '.delimit'), { recursive: true });
+        fs.writeFileSync(
+            path.join(regHome, '.delimit', 'active_venture.json'),
+            JSON.stringify({ venture: 'wire-report', repoRoot: null })
+        );
+        const bareHome = path.join(tmpDir, 'home-without-registry');
+        fs.mkdirSync(bareHome, { recursive: true });
+
+        const harness =
+            `import os, json\n${pySnippet}\n` +
+            `print(_resolve_venture("/root"))\n` +               // neutral -> registry
+            `print(_resolve_venture(os.path.expanduser("~")))\n` + // own home -> registry
+            `print(_resolve_venture("/home/x/delimit-gateway"))\n` + // real venture dir wins
+            `print(_resolve_venture(""))\n`;                     // empty -> registry
+        const withReg = execSync('python3', { input: harness, env: { ...process.env, HOME: regHome } })
+            .toString().trim().split('\n');
+        assert.deepStrictEqual(withReg, ['wire-report', 'wire-report', 'delimit-gateway', 'wire-report']);
+
+        // Accepted floor without a registry: neutral cwds fall back to their
+        // basename ("/root" -> "root", the home dir -> its basename), empty
+        // falls to "all" — exactly the pre-LED-4244 behavior.
+        const noReg = execSync('python3', { input: harness, env: { ...process.env, HOME: bareHome } })
+            .toString().trim().split('\n');
+        assert.deepStrictEqual(noReg, ['root', 'home-without-registry', 'delimit-gateway', 'all']);
+    });
+
     it('is not installed when agent_record is false', () => {
         const claudeDir = path.join(tmpDir, '.claude');
         fs.mkdirSync(claudeDir, { recursive: true });

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 // CI environments do not have the full gateway/lib stack installed, so tests
 // that spawn the CLI via execSync or depend on uncommitted lib changes will
@@ -18,16 +18,27 @@ const crossModelHooks = require('../lib/cross-model-hooks');
 
 // Test helpers
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DELIMIT_HOME = process.env.DELIMIT_HOME;
+const ORIGINAL_NAMESPACE_ROOT = process.env.DELIMIT_NAMESPACE_ROOT;
 let tmpDir;
 
 function setupTmpHome() {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-hooks-test-'));
     process.env.HOME = tmpDir;
+    delete process.env.DELIMIT_HOME;
+    delete process.env.DELIMIT_NAMESPACE_ROOT;
     return tmpDir;
 }
 
 function teardownTmpHome() {
     process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_DELIMIT_HOME === undefined) delete process.env.DELIMIT_HOME;
+    else process.env.DELIMIT_HOME = ORIGINAL_DELIMIT_HOME;
+    if (ORIGINAL_NAMESPACE_ROOT === undefined) {
+        delete process.env.DELIMIT_NAMESPACE_ROOT;
+    } else {
+        process.env.DELIMIT_NAMESPACE_ROOT = ORIGINAL_NAMESPACE_ROOT;
+    }
     if (tmpDir && fs.existsSync(tmpDir)) {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -134,6 +145,11 @@ describe('installClaudeHooks', () => {
         const sessionGroup = config.hooks.SessionStart[0];
         assert.ok(sessionGroup.hooks, 'SessionStart should use nested format');
         assert.ok(sessionGroup.hooks[0].command.includes('delimit') || sessionGroup.hooks[0].command.includes('hooks'));
+        assert.strictEqual(
+            sessionGroup.hooks[0].timeout,
+            20,
+            'outer budget covers 6s digest + 8s continuity with margin',
+        );
         assert.strictEqual(sessionGroup.if, undefined, 'SessionStart should have no if condition');
 
         // PreToolUse should have the spec-scoped hook in nested format
@@ -181,6 +197,54 @@ describe('installClaudeHooks', () => {
         assert.strictEqual(config.hooks.PreToolUse.length, 4, 'Should have exactly four PreToolUse hooks');
         // spec-lint + STR-2202 agent-record = 2
         assert.strictEqual(config.hooks.PostToolUse.length, 2, 'Should have exactly two PostToolUse hooks (spec-lint + agent-record)');
+    });
+
+    it('collapses seeded duplicate SessionStart delegates without dropping unrelated hooks', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+
+        const tool = {
+            id: 'claude',
+            name: 'Claude Code',
+            configPath: path.join(claudeDir, 'settings.json'),
+        };
+        const hookConfig = {
+            session_start: true,
+            pre_tool: false,
+            pre_commit: false,
+            conditional_hooks: false,
+            agent_record: false,
+        };
+
+        crossModelHooks.installClaudeHooks(tool, hookConfig);
+        const seeded = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        const exactGroup = seeded.hooks.SessionStart[0];
+        const exactCommand = exactGroup.hooks[0].command;
+        seeded.hooks.SessionStart.push({
+            matcher: '',
+            hooks: [
+                { ...exactGroup.hooks[0], timeout: 10 },
+                { type: 'command', command: '/usr/local/bin/user-session-start' },
+            ],
+        });
+        fs.writeFileSync(tool.configPath, JSON.stringify(seeded));
+
+        const changes = crossModelHooks.installClaudeHooks(tool, hookConfig);
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        const commands = config.hooks.SessionStart.flatMap(
+            group => (group.hooks || []).map(hook => hook.command),
+        );
+        const exactDelegates = config.hooks.SessionStart.flatMap(
+            group => (group.hooks || []).filter(hook => hook.command === exactCommand),
+        );
+
+        assert.ok(changes.includes('SessionStart'), 'duplicate normalization is reported');
+        assert.strictEqual(exactDelegates.length, 1, 'exactly one Delimit delegate remains');
+        assert.strictEqual(exactDelegates[0].timeout, 20, 'canonical timeout is retained');
+        assert.ok(
+            commands.includes('/usr/local/bin/user-session-start'),
+            'unrelated hook from a mixed group is preserved',
+        );
     });
 
     it('preserves existing settings.json content', () => {
@@ -952,18 +1016,84 @@ describe('LED-1962 SessionStart auto-revive last soul', () => {
         // The marker printed into the new session, and the module it imports.
         assert.ok(script.includes('Auto-revived working context'), 'emits the auto-revive marker');
         assert.ok(script.includes('session_phoenix'), 'imports ai.session_phoenix');
-        assert.ok(script.includes('get_latest_soul'), 'revives the current-project soul');
-        // Cross-project fallback is OPT-IN and OFF by default — a soul from a
-        // different project/venture must not bleed into this (possibly public) session.
-        assert.ok(script.includes('DELIMIT_AUTO_REVIVE_GLOBAL=""'),
-            'cross-project fallback OFF by default');
-        assert.ok(script.includes('DELIMIT_AUTO_REVIVE_GLOBAL") == "1"'),
-            'global fallback is env-guarded (opt-in only)');
+        assert.ok(script.includes('from ai import session_phoenix as backend'),
+            'uses one reconcile+revive Session Phoenix delegate');
+        assert.ok(script.includes('CONTINUITY_PROTOCOL_VERSION'),
+            'rejects legacy backends without the event-bound protocol');
+        assert.ok(script.includes('"current_transcript_path": event.get("transcript_path"'),
+            'binds reconciliation to the SessionStart event transcript');
+        assert.ok(script.includes('"project_path": exact["project_path"]'),
+            'revives the exact reconciled project');
+        assert.ok(script.includes('"soul_id": exact["soul_id"]'),
+            'revives the exact reconciled soul');
+        assert.ok(script.includes('"transcript_path": ""'),
+            'does not re-resolve the receiver empty transcript');
+        assert.ok(script.includes('"session_id": event.get("session_id"'),
+            'passes the logical Claude session id');
+        assert.ok(script.includes('"chat_run_id": launcher_run'),
+            'passes the stable Delimit Chat run id');
+        assert.ok(!script.includes('get_latest_soul'), 'never reads a cwd soul directly');
+        assert.ok(!script.includes('find_most_recent_soul_across_projects'),
+            'never performs a blind global-most-recent revival');
+        // A soul from a different project/venture must never bleed into this
+        // session through a blind global-most-recent fallback.
+        assert.ok(!script.includes('DELIMIT_AUTO_REVIVE_GLOBAL'),
+            'generated hook has no blind global fallback switch');
         // Never-block contract: time-boxed + fails open, orchestrator-only.
-        assert.ok(script.includes("timeout 6 python3 - <<'RVEOF'"), 'revive is time-boxed');
-        assert.ok(/RVEOF' 2>\/dev\/null \|\| true/.test(script), 'revive fails open (|| true)');
+        assert.ok(script.includes("timeout 8 python3 - <<'PYEOF'"), 'delegate is time-boxed');
+        assert.ok(/PYEOF' 2>\/dev\/null \|\| true/.test(script), 'delegate fails open (|| true)');
         assert.ok(script.includes('"$DELIMIT_SESSION_TYPE" != "subagent"'),
             'revive skipped for subagents');
+        assert.ok(
+            script.indexOf("timeout 6 python3 - <<'DGEOF'")
+                < script.indexOf("timeout 8 python3 - <<'PYEOF'"),
+            'optional digest work runs before the delivery/ack phase',
+        );
+        assert.ok(
+            script.indexOf('=== Delimit Ready ===')
+                < script.indexOf("timeout 8 python3 - <<'PYEOF'"),
+            'continuity delivery is the final output-producing phase',
+        );
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        assert.strictEqual(
+            config.hooks.SessionStart[0].hooks[0].timeout,
+            20,
+            'outer hook budget cannot expire after a valid 8s revive',
+        );
+    });
+
+    it('upgrades an existing SessionStart outer timeout to the safe budget', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        const hooksDir = path.join(claudeDir, 'hooks');
+        fs.mkdirSync(hooksDir, { recursive: true });
+        const hookPath = path.join(hooksDir, 'delimit');
+        const tool = {
+            id: 'claude',
+            name: 'Claude Code',
+            configPath: path.join(claudeDir, 'settings.json'),
+        };
+        fs.writeFileSync(tool.configPath, JSON.stringify({
+            hooks: {
+                SessionStart: [{
+                    matcher: '',
+                    hooks: [{
+                        type: 'command',
+                        command: hookPath,
+                        timeout: 10,
+                    }],
+                }],
+            },
+        }));
+
+        const changes = crossModelHooks.installClaudeHooks(tool, {
+            session_start: true,
+        });
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        assert.ok(changes.includes('SessionStart:timeout'));
+        assert.strictEqual(
+            config.hooks.SessionStart[0].hooks[0].timeout,
+            20,
+        );
     });
 
     it('omits the auto-revive block when session_auto_revive is false', () => {
@@ -974,12 +1104,13 @@ describe('LED-1962 SessionStart auto-revive last soul', () => {
         crossModelHooks.installClaudeHooks(tool, { session_start: true, session_auto_revive: false });
 
         const script = fs.readFileSync(path.join(claudeDir, 'hooks', 'delimit'), 'utf-8');
-        assert.ok(!script.includes('Auto-revived working context'),
-            'auto-revive marker omitted when flag is false');
-        assert.ok(!script.includes("<<'RVEOF'"), 'auto-revive block omitted when flag is false');
+        assert.ok(script.includes('if False:'),
+            'single delegate disables the revive branch when configured off');
+        assert.ok(!script.includes('if True:'),
+            'disabled configuration cannot enter the revive branch');
     });
 
-    it('enables cross-project fallback only when session_auto_revive_global is true', () => {
+    it('does not restore blind global fallback for the legacy config flag', () => {
         const claudeDir = path.join(tmpDir, '.claude');
         fs.mkdirSync(claudeDir, { recursive: true });
         const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
@@ -987,8 +1118,8 @@ describe('LED-1962 SessionStart auto-revive last soul', () => {
         crossModelHooks.installClaudeHooks(tool, { session_start: true, session_auto_revive_global: true });
 
         const script = fs.readFileSync(path.join(claudeDir, 'hooks', 'delimit'), 'utf-8');
-        assert.ok(script.includes('DELIMIT_AUTO_REVIVE_GLOBAL="1"'),
-            'cross-project fallback enabled when opted in');
+        assert.ok(!script.includes('DELIMIT_AUTO_REVIVE_GLOBAL'),
+            'legacy flag cannot re-enable unsafe global-most-recent revival');
         assert.ok(script.includes('Auto-revived working context'), 'still emits the revive block');
     });
 
@@ -1002,6 +1133,125 @@ describe('LED-1962 SessionStart auto-revive last soul', () => {
         const hookPath = path.join(claudeDir, 'hooks', 'delimit');
         // Throws (non-zero exit) if the generated script is not valid bash.
         execSync(`bash -n ${JSON.stringify(hookPath)}`, { stdio: 'pipe' });
+    });
+
+    it('executes one delegate and revives the exact reconciled soul once', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        const serverDir = path.join(tmpDir, '.delimit', 'server', 'ai');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        fs.mkdirSync(serverDir, { recursive: true });
+        fs.writeFileSync(path.join(serverDir, '__init__.py'), '');
+        fs.writeFileSync(path.join(serverDir, 'session_phoenix.py'), `
+import json, os
+CONTINUITY_PROTOCOL_VERSION = 2
+def _log(name, values):
+    with open(os.environ["FAKE_CALL_LOG"], "a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"name": name, "values": values}) + "\\n")
+def reconcile_orphan(
+    transcript_path="", project_path="", current_transcript_path="",
+    session_id="", chat_run_id="", reason="",
+):
+    kwargs = locals()
+    _log("reconcile", kwargs)
+    return {
+        "status": "reconciled",
+        "capture_key": "abc123",
+        "salvaged_handoff": {
+            "project_path": "/portfolio/delimit-gateway",
+            "soul_id": "soul-exact",
+        },
+    }
+def revive(
+    project_path="", soul_id="", transcript_path="", session_id="",
+    chat_run_id="",
+):
+    kwargs = locals()
+    _log("revive", kwargs)
+    return {
+        "status": "revived",
+        "context": "EXACT LED-4057 CONTEXT",
+        "delivery_ack": {
+            "capture_key": "abc123",
+            "transcript_path": "/portfolio/root/orphan.jsonl",
+            "logical_session_id": "sender-session",
+            "launcher_run_id": chat_run_id,
+            "write_id": "generation-1",
+        },
+    }
+def acknowledge_revival(
+    capture_key="", transcript_path="", logical_session_id="",
+    launcher_run_id="", write_id="",
+):
+    kwargs = locals()
+    _log("acknowledge", kwargs)
+    return {"status": "acknowledged"}
+`);
+        const tool = {
+            id: 'claude',
+            name: 'Claude Code',
+            configPath: path.join(claudeDir, 'settings.json'),
+        };
+        crossModelHooks.installClaudeHooks(tool, {
+            session_start: true,
+            session_digest_echo: false,
+        });
+        const hookPath = path.join(claudeDir, 'hooks', 'delimit');
+        const callLog = path.join(tmpDir, 'calls.jsonl');
+        const event = {
+            transcript_path: '/portfolio/root/current-empty.jsonl',
+            session_id: 'receiver-session',
+            reason: 'session-start',
+        };
+        const hookEnv = {
+            ...process.env,
+            HOME: tmpDir,
+            DELIMIT_NAMESPACE_ROOT: path.join(tmpDir, '.delimit'),
+            DELIMIT_CHAT_RUN_ID: 'chat-run-4057',
+            FAKE_CALL_LOG: callLog,
+        };
+        delete hookEnv.DELIMIT_HOME;
+        const run = spawnSync(hookPath, [], {
+            input: JSON.stringify(event),
+            encoding: 'utf-8',
+            env: hookEnv,
+        });
+        assert.strictEqual(run.status, 0, run.stderr);
+        assert.strictEqual(
+            (run.stdout.match(/Auto-revived working context/g) || []).length,
+            1,
+            run.stdout,
+        );
+        assert.ok(run.stdout.includes('EXACT LED-4057 CONTEXT'));
+        const calls = fs.readFileSync(callLog, 'utf-8')
+            .trim().split('\n').map(line => JSON.parse(line));
+        assert.deepStrictEqual(
+            calls.map(call => call.name),
+            ['reconcile', 'revive', 'acknowledge'],
+        );
+        assert.strictEqual(
+            calls[0].values.current_transcript_path,
+            event.transcript_path,
+        );
+        assert.strictEqual(
+            calls[1].values.project_path,
+            '/portfolio/delimit-gateway',
+        );
+        assert.strictEqual(calls[1].values.soul_id, 'soul-exact');
+        assert.strictEqual(calls[1].values.transcript_path, '');
+        assert.strictEqual(calls[1].values.chat_run_id, 'chat-run-4057');
+        assert.strictEqual(calls[2].values.capture_key, 'abc123');
+        assert.strictEqual(calls[2].values.write_id, 'generation-1');
+        assert.strictEqual(calls[2].values.launcher_run_id, 'chat-run-4057');
+        const hookSource = fs.readFileSync(hookPath, 'utf-8');
+        assert.ok(
+            hookSource.indexOf('sys.stdout.flush()')
+                < hookSource.indexOf('call(acknowledge_revival, delivery_ack)'),
+            'delivery bytes are flushed before the generation is acknowledged',
+        );
+        assert.ok(
+            hookSource.includes('$DELIMIT_NAMESPACE_ROOT'),
+            'runtime namespace fallback is retained in the generated hook',
+        );
     });
 
     it('Codex instructions.md carries the strengthened first-action revive text', () => {
@@ -1175,7 +1425,7 @@ describe('SessionEnd hook install', () => {
         }
     });
 
-    it('the deployed script does a deterministic, no-LLM floor capture (git + ledger + transcript tail)', () => {
+    it('delegates project-bound finalization without inline cwd/global capture logic', () => {
         const claudeDir = path.join(tmpDir, '.claude');
         fs.mkdirSync(claudeDir, { recursive: true });
         const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
@@ -1186,14 +1436,70 @@ describe('SessionEnd hook install', () => {
         // Reads the SessionEnd event JSON from stdin for transcript_path.
         assert.ok(s.includes('SESSIONEND_EVENT_JSON'), 'reads the SessionEnd event JSON');
         assert.ok(s.includes('transcript_path'), 'reads transcript_path');
-        // Deterministic floor: git state + ledger + transcript tail, NO model call.
-        assert.ok(s.includes('rev-parse') && s.includes('status'), 'captures git state');
-        assert.ok(s.includes('operations.jsonl'), 'captures cheap ledger context');
-        assert.ok(s.includes('"source": "deterministic"'), 'floor is deterministic (no LLM)');
-        assert.ok(s.includes('.last_capture'), 'stamps .last_capture for next revive');
+        assert.ok(s.includes('from ai import session_phoenix as backend'),
+            'delegates to the canonical Session Phoenix capture API');
+        assert.ok(s.includes('CONTINUITY_PROTOCOL_VERSION'),
+            'rejects an older unsafe Session Phoenix backend');
+        assert.ok(s.includes('"session_id": event.get("session_id"'),
+            'passes the logical session id');
+        assert.ok(s.includes('"reason": event.get("reason"'),
+            'passes the SessionEnd reason');
+        assert.ok(s.includes('"trigger": "session-end"'), 'marks the finalizing trigger');
+        assert.ok(s.includes('"finalize": True'), 'finalizes the provisional Stop upsert');
+        assert.ok(s.includes('DELIMIT_CHAT_RUN_ID'), 'binds the capture to its launcher run');
+        for (const forbidden of [
+            '"venture": "all"',
+            'operations.jsonl',
+            'git commit',
+            '--no-verify',
+            'rev-parse',
+            'session_" + time.strftime',
+        ]) {
+            assert.ok(!s.includes(forbidden), `does not contain unsafe inline capture: ${forbidden}`);
+        }
         // Never-block contract: time-boxed + always exits 0.
         assert.ok(s.includes("timeout 8 python3"), 'time-boxed (<10s)');
         assert.ok(/exit 0\s*$/.test(s.trim()), 'always exits 0 (never blocks exit)');
+    });
+
+    it('Stop is a provisional thin upsert and all lifecycle scripts exclude legacy writers', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true });
+
+        const scriptNames = ['delimit', 'delimit-stop', 'delimit-session-end'];
+        const scripts = scriptNames
+            .map(name => fs.readFileSync(path.join(claudeDir, 'hooks', name), 'utf-8'));
+        const stop = scripts[1];
+        assert.ok(stop.includes('capture_floor_from_transcript'));
+        assert.ok(stop.includes('"trigger": "stop"'));
+        assert.ok(stop.includes('"finalize": False'));
+        assert.ok(stop.includes('"session_id": event.get("session_id"'));
+        assert.ok(stop.includes('backend-upgrade-required'), 'old unsafe backend fails closed');
+        assert.ok(stop.includes('already_captured:*|noop:*'),
+            'repeated Stop events report an existing durable floor as saved');
+
+        for (const script of scripts) {
+            assert.ok(
+                script.includes('$DELIMIT_NAMESPACE_ROOT'),
+                'every lifecycle hook honors the namespace fallback',
+            );
+            for (const forbidden of [
+                '"venture": "all"',
+                'operations.jsonl',
+                '--no-verify',
+                'find_most_recent_soul_across_projects',
+                'session_" + time.strftime',
+            ]) {
+                assert.ok(!script.includes(forbidden), `generated lifecycle hook excludes ${forbidden}`);
+            }
+        }
+        for (const name of scriptNames) {
+            const hookPath = path.join(claudeDir, 'hooks', name);
+            execSync(`bash -n ${JSON.stringify(hookPath)}`, { stdio: 'pipe' });
+        }
     });
 
     it('is idempotent — installing twice yields exactly one SessionEnd group', () => {

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -1062,6 +1062,29 @@ describe('LED-1962 SessionStart auto-revive last soul', () => {
         );
     });
 
+    it('preserves startup status and critical handoff post-flight before continuity delivery', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true });
+
+        const script = fs.readFileSync(path.join(claudeDir, 'hooks', 'delimit'), 'utf-8');
+        assert.ok(script.includes('=== Delimit Status ==='), 'startup status remains visible');
+        assert.ok(script.includes('Governance: active | policy=project'), 'governance probe remains');
+        assert.ok(script.includes('Server: ready ($TOOLS tools)'), 'server/tool probe remains');
+        assert.ok(script.includes('MCP: delimit registered'), 'MCP probe remains');
+        assert.ok(script.includes('Recent sessions (revive full state via'), 'session index remains');
+        assert.ok(script.includes('Session: subagent (scoped)'), 'subagent index remains scoped');
+        assert.ok(script.includes('Handoff post-flight:'), 'critical handoff post-flight remains');
+        assert.ok(script.includes('from ai.handoff_preflight import preflight_check'),
+            'post-flight still delegates to the canonical validator');
+        assert.ok(
+            script.indexOf('Handoff post-flight:') < script.indexOf('acknowledge_revival'),
+            'optional diagnostics run before the final continuity delivery/ack phase',
+        );
+    });
+
     it('upgrades an existing SessionStart outer timeout to the safe budget', () => {
         const claudeDir = path.join(tmpDir, '.claude');
         const hooksDir = path.join(claudeDir, 'hooks');
@@ -1368,6 +1391,29 @@ describe('STR-2202 subagent flight-recorder (PostToolUse)', () => {
         const noReg = execSync('python3', { input: harness, env: { ...process.env, HOME: bareHome } })
             .toString().trim().split('\n');
         assert.deepStrictEqual(noReg, ['root', 'home-without-registry', 'delimit-gateway', 'all']);
+
+        // Namespace isolation: DELIMIT_HOME is the active namespace root and
+        // must outrank a stale registry under the user's default ~/.delimit.
+        const namespacedHome = path.join(tmpDir, 'namespaced-home');
+        const namespaceRoot = path.join(tmpDir, 'namespace-root');
+        fs.mkdirSync(path.join(namespacedHome, '.delimit'), { recursive: true });
+        fs.mkdirSync(namespaceRoot, { recursive: true });
+        fs.writeFileSync(
+            path.join(namespacedHome, '.delimit', 'active_venture.json'),
+            JSON.stringify({ venture: 'stale-global-venture' })
+        );
+        fs.writeFileSync(
+            path.join(namespaceRoot, 'active_venture.json'),
+            JSON.stringify({ venture: 'namespace-venture' })
+        );
+        const namespaced = execSync('python3', {
+            input: harness,
+            env: { ...process.env, HOME: namespacedHome, DELIMIT_HOME: namespaceRoot },
+        }).toString().trim().split('\n');
+        assert.deepStrictEqual(
+            namespaced,
+            ['namespace-venture', 'namespace-venture', 'delimit-gateway', 'namespace-venture'],
+        );
     });
 
     it('is not installed when agent_record is false', () => {


### PR DESCRIPTION
## Summary

Supersedes stale PR #188 on current v4.18.6 main.

- route Claude Stop and SessionEnd through the project-bound Session Phoenix v2 capture API instead of hardcoded `venture: "all"` and legacy inline/global writers
- bind `delimit chat` capture, revive, and delivery acknowledgement to one stable launcher run across model switches
- fail closed on ambiguous project resolution, old backends, and unconfirmed Codex delivery
- resolve neutral-cwd recorder attribution through the active Delimit namespace before the default home registry
- preserve startup status, recent-session index, digest, critical handoff post-flight, hook no-clobber, timeouts, and exit-zero behavior

The legacy Stop-hook `git add`/`commit --no-verify`/push mutation is intentionally removed. Durable capture belongs to Session Phoenix, and repository doctrine prohibits bypassing pre-commit hooks.

## Evidence

- focused continuity/hook suites: 87/87
- full npm suite: 399/399
- pre-push full suite: 399/399
- repo diagnose: healthy, 0 issues
- production dependency audit: 0 critical; existing three moderate transitive `express`/`body-parser`/`qs` findings unchanged by this dependency-free patch
- exact-diff deliberation: RELEASE after fixing status preservation and namespace isolation (`led4057-npm-current-main-v4.json`)

## Scope

Four source/test files only. No package publication, hook installation, or live runtime deployment in this PR.

Closes LED-4057 after merge, release, and installed-hook verification.
