### PR TITLE
fix(security): pin patched FastMCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Security
+- Pin FastMCP 3.2.4 across bundled requirements, setup fallbacks, and the
+  container fallback, clearing PYSEC-2026-2475 and PYSEC-2026-2476 for fresh
+  installs while preserving the tested FastMCP 3.x runtime line.
+
 ## [4.18.6] - 2026-09-06
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY gateway/requirements.txt ./
 # image run the same fastmcp (fresh-user install test 2026-09-02, finding 7:
 # the unpinned fallback landed on 4.0.2 while setup venvs ran 3.1.0).
 RUN pip install --no-cache-dir -r requirements.txt 2>/dev/null \
-    || pip install --no-cache-dir fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 "mcp>=1.28.1"
+    || pip install --no-cache-dir fastmcp==3.2.4 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 "mcp>=1.28.1"
 
 # Copy the MCP server
 COPY gateway/ ./gateway/

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -270,17 +270,17 @@ async function main() {
             // the delimit_test_smoke deploy-gate step fails to run cleanly.
             execSync(`"${venvPy}" -m pip install --quiet pytest 2>/dev/null`, { stdio: 'pipe' });
         } else {
-            execSync(`"${venvPy}" -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
+            execSync(`"${venvPy}" -m pip install --quiet fastmcp==3.2.4 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
         }
         python = venvPy;  // Use venv python for MCP config
         await logp(`  ${green('✓')} Python dependencies installed (isolated venv)`);
     } catch {
         log(`  ${yellow('!')} venv install failed — trying global pip`);
         try {
-            execSync(`${python} -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
+            execSync(`${python} -m pip install --quiet fastmcp==3.2.4 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
             await logp(`  ${green('✓')} Python dependencies installed (global)`);
         } catch {
-            log(`  ${yellow('!')} pip install failed — run manually: pip install fastmcp pyyaml pydantic packaging pytest`);
+            log(`  ${yellow('!')} pip install failed — run manually: pip install fastmcp==3.2.4 pyyaml pydantic packaging pytest`);
         }
     }
     // LED-1084 week 2: build the content-grounding feature whitelist.

--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -665,7 +665,7 @@ def _construct_mcp(name: str, version: str):
     """Build the FastMCP app so the MCP ``initialize`` handshake reports OUR
     version. Without ``version=`` fastmcp advertises its own library version
     as ``serverInfo.version`` (fresh-user install test 2026-09-02, finding 6:
-    "3.1.0" on a setup venv, "4.0.2" in Docker). Older fastmcp releases
+    "3.2.4" on a setup venv, "4.0.2" in Docker). Older fastmcp releases
     without the kwarg must still start (never-break-installs)."""
     try:
         return FastMCP(name, version=version)

--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -665,7 +665,7 @@ def _construct_mcp(name: str, version: str):
     """Build the FastMCP app so the MCP ``initialize`` handshake reports OUR
     version. Without ``version=`` fastmcp advertises its own library version
     as ``serverInfo.version`` (fresh-user install test 2026-09-02, finding 6:
-    "3.2.4" on a setup venv, "4.0.2" in Docker). Older fastmcp releases
+    "3.1.0" on a setup venv, "4.0.2" in Docker). Older fastmcp releases
     without the kwarg must still start (never-break-installs)."""
     try:
         return FastMCP(name, version=version)

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -14,9 +14,9 @@
 # unpinned fallback, so the two surfaces ran different fastmcp majors ("3.1.0"
 # vs "4.0.2"). One version everywhere: this pin, the delimit-setup.js no-reqfile
 # fallback, and the Dockerfile fallback MUST all say the same fastmcp.
-# 3.1.0 accepts FastMCP(version=...) (serverInfo.version) and constrains
-# mcp<2.0,>=1.24.0, so the LED-3840 floor below still resolves.
-fastmcp==3.1.0
+# 3.2.4 accepts FastMCP(version=...), constrains mcp<2.0,>=1.24.0, and clears
+# PYSEC-2026-2475 / PYSEC-2026-2476 (fixed in fastmcp 3.2.0).
+fastmcp==3.2.4
 pydantic>=2.0.0
 pyyaml>=6.0
 packaging>=23.0

--- a/tests/bundle-parity-guard.test.js
+++ b/tests/bundle-parity-guard.test.js
@@ -26,6 +26,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const REPO_ROOT = path.join(__dirname, '..');
+const FASTMCP_PIN = 'fastmcp==3.2.4';
 
 function writeFile(dir, rel, body = '# content\n') {
   const p = path.join(dir, rel);
@@ -212,5 +213,33 @@ describe('non-authoritative build artifacts', () => {
     assert.ok(!pkg.files.includes(staleManifest));
     assert.ok(!allowlist.split(/\r?\n/).includes(staleManifest));
     assert.ok(!fs.existsSync(path.join(REPO_ROOT, staleManifest)));
+  });
+});
+
+describe('FastMCP fresh-install security parity (LED-4530)', () => {
+  it('pins the patched runtime in the shipped requirements', () => {
+    const requirements = fs.readFileSync(
+      path.join(REPO_ROOT, 'gateway', 'requirements.txt'),
+      'utf8'
+    );
+    assert.ok(requirements.split(/\r?\n/).includes(FASTMCP_PIN));
+    assert.doesNotMatch(requirements, /fastmcp==3\.1\.0/);
+  });
+
+  it('uses the identical pin in every setup and container fallback', () => {
+    const dockerfile = fs.readFileSync(path.join(REPO_ROOT, 'Dockerfile'), 'utf8');
+    const setup = fs.readFileSync(
+      path.join(REPO_ROOT, 'bin', 'delimit-setup.js'),
+      'utf8'
+    );
+
+    assert.ok(dockerfile.includes(FASTMCP_PIN));
+    assert.strictEqual(
+      (setup.match(/fastmcp==3\.2\.4/g) || []).length,
+      3,
+      'venv, global, and manual recovery paths must share the patched pin'
+    );
+    assert.doesNotMatch(dockerfile, /fastmcp==3\.1\.0/);
+    assert.doesNotMatch(setup, /fastmcp==3\.1\.0/);
   });
 });


### PR DESCRIPTION
## Summary
- pin FastMCP 3.2.4 in bundled requirements and every setup/container fallback
- prevent fresh installs from resolving FastMCP 3.1.x, affected by PYSEC-2026-2475 and PYSEC-2026-2476
- add fresh-install and bundle-parity regression coverage
- integrate current main at 780da1c7c17a959deee52f60b5a2c62701e3b7a8 without force-pushing

## Evidence
- final head: 07134a247713ed971a4f535f8741825cf161a524
- npm test: 401 passed
- pre-push suite: 401 passed
- focused bundle-parity guard: 11 passed
- node syntax checks: passed
- pip-audit gateway/requirements.txt: no known vulnerabilities
- npm audit --omit=dev --audit-level=high: no high-severity findings; three pre-existing moderate Express/qs findings remain documented
- exact full-index diff: /tmp/led-4530-exact-patches/npm-rebased-final.diff (SHA-256 4c0a405775f09a0baaec3a360d93f8f6493373657e17d5e6d88a986212315349)
- literal exact-head diff review: unanimous MERGE AUTHORIZED, transcript /root/.delimit/deliberations/deliberation_20260907_041800.json
- hosted checks: 13/13 successful on the final head

## Release
A new npm package release is required after merge for customer fresh installs to receive the patched setup paths. This PR does not publish or deploy.