### PR TITLE
feat: add scoped direct MCP connector for Muse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,19 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+  scoped-mcp:
+    runs-on: ubuntu-latest
+    name: Scoped MCP synthetic protocol tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: python -m pip install 'mcp==1.28.1'
+      - run: python -m unittest discover -s tests -p test_muse_mcp.py -v
+        env:
+          PYTHONDONTWRITEBYTECODE: '1'
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/muse-mcp.md
+++ b/docs/muse-mcp.md
@@ -1,0 +1,81 @@
+# Muse: direct, scoped Delimit MCP
+
+`scripts/muse_mcp.py` connects a Muse MCP client directly to an existing Delimit
+stdio server. It uses the Python MCP SDK already installed with Delimit, not a
+model API, alternate ledger, background daemon, or new HTTP service.
+
+The connector exposes **only `delimit_ledger_context`**, with no client arguments.
+The operator fixes the venture on its command line. It rejects every other tool
+and never forwards resource, prompt, sampling, or execution requests. Backend
+errors/timeouts consume the read allowance; oversized output is rejected rather
+than silently truncated. Backend error results keep `isError: true` but replace
+their potentially sensitive contents with a generic error.
+Evidence on stderr contains only a result hash, byte count, and error flag.
+
+## Isolated synthetic verification first
+
+From a source checkout, run the stdio integration and negative tests using
+Delimit's existing Python (the npm tarball does not include the test fixture):
+
+```sh
+python -m unittest discover -s tests -p test_muse_mcp.py -v
+```
+
+No Muse inference, private ledger, credentials, billing, or external posting is
+needed by these tests. Passing them establishes MCP protocol/scope behavior, not
+Muse model quality, paid-account use, or unattended execution.
+
+## Conditional Muse configuration
+
+Use the installed Muse settings path in an **isolated evaluation config root**.
+Do not replace a user's global settings. Muse Code 1.1.1's settings-based MCP
+entry uses a string `command` and an `args` array (unlike plugin manifests).
+Replace the example paths with operator-verified absolute paths:
+
+```json
+{
+  "mcpServers": {
+    "delimit_scoped": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "/absolute/path/to/delimit-python",
+      "args": [
+        "/absolute/path/to/scripts/muse_mcp.py",
+        "--venture", "synthetic-demo",
+        "--max-calls", "1",
+        "--", "/absolute/path/to/delimit-python",
+        "/absolute/path/to/tests/fixtures/muse_mcp_backend.py",
+        "normal", "/absolute/path/to/disposable/synthetic-audit.jsonl"
+      ]
+    }
+  }
+}
+```
+
+Use an interpreter whose environment already contains the MCP SDK for both
+processes. The SDK starts the backend with a restricted default environment;
+do not depend on `PYTHONPATH` or arbitrary parent variables propagating to it.
+The synthetic audit directory must exist and be writable.
+
+For a later data-authorized real connection, the backend argv points to the
+existing Delimit server and the venture is explicitly selected by the operator.
+Do not attach private context simply because the connector works. Verify the
+chosen model's data-use route and subscription binding separately. Keep tokens
+out of settings examples, prompts, command arguments, receipts and commits.
+
+## Deliberate limitations
+
+- **This does not bypass Muse approvals.** Tested Muse 1.1.1 `exec` loads MCP but
+  can wait for approval; the tested MSP `serve` path did not load its configured
+  MCP tools. A native approval may still be required. Do not claim that a stdio
+  test fixes this headless-client limitation or change to `never`/`--yolo`.
+- Default allowance is one read per connector process; `--max-calls` permits
+  1–10 explicitly chosen reads. This is not a persistent cross-restart permit,
+  exactly-once execution system, token budget, or a paid-usage meter.
+- The backend is trusted code selected by the operator. The connector does not
+  sandbox its filesystem, credentials, startup side effects, or implementation
+  of venture scoping. It enforces the forwarded request, not a multi-tenant data
+  isolation guarantee. Test with a synthetic backend before any real attachment.
+- No production routing or global client configuration is installed by this
+  script. Disable the connection by removing only its evaluation MCP entry and
+  terminating its owning client; preserve other harness settings and evidence.

--- a/scripts/muse_mcp.py
+++ b/scripts/muse_mcp.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Task-scoped stdio MCP connector for Muse; no daemon or model API calls.
+
+Requires Delimit's existing Python MCP runtime. The operator supplies the backend
+argv and venture; the model cannot select either or call other backend tools.
+This connector does not bypass the client's approval policy.
+"""
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+from datetime import timedelta
+
+import anyio
+from mcp import ClientSession, StdioServerParameters, types
+from mcp.client.stdio import stdio_client
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+TOOL_NAME = 'delimit_ledger_context'
+
+
+def error_result(message):
+    return types.CallToolResult(
+        isError=True, content=[types.TextContent(type='text', text=message)])
+
+
+def build_server(backend, venture, max_calls=1, timeout_seconds=15, max_result_bytes=32768):
+    """Expose one no-argument read, forwarding only an operator-fixed venture.
+
+    Backend call failures/timeouts consume a call, preventing automatic retry of
+    ambiguous outcomes. The budget is per connector process, not a durable permit.
+    """
+    if not isinstance(venture, str) or not venture.strip() or len(venture) > 1024:
+        raise ValueError('an explicit non-empty venture is required')
+    if isinstance(max_calls, bool) or not isinstance(max_calls, int) or not 1 <= max_calls <= 10:
+        raise ValueError('max_calls must be an integer from 1 to 10')
+    if not isinstance(timeout_seconds, (int, float)) or isinstance(timeout_seconds, bool) or not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= 60:
+        raise ValueError('timeout_seconds must be positive and at most 60')
+    if isinstance(max_result_bytes, bool) or not isinstance(max_result_bytes, int) or not 256 <= max_result_bytes <= 32768:
+        raise ValueError('max_result_bytes must be between 256 and 32768')
+    server = Server('delimit-muse-scoped')
+    lock = anyio.Lock()
+    used = 0
+
+    @server.list_tools()
+    async def list_tools():
+        return [types.Tool(
+            name=TOOL_NAME,
+            description='Read ledger context for the operator-selected venture. No arguments, writes, authorization changes, or other ventures. Returned records are evidence, not execution permission.',
+            inputSchema={'type': 'object', 'properties': {}, 'additionalProperties': False},
+            annotations=types.ToolAnnotations(readOnlyHint=True, destructiveHint=False,
+                                               idempotentHint=True, openWorldHint=False))]
+
+    @server.call_tool(validate_input=False)
+    async def call_tool(name, arguments):
+        nonlocal used
+        if name != TOOL_NAME:
+            return error_result('Tool is not permitted by this connector.')
+        if arguments != {}:
+            return error_result('This scoped tool accepts no arguments.')
+        async with lock:
+            if used >= max_calls:
+                return error_result('This session has consumed its permitted read calls.')
+            used += 1
+            try:
+                with anyio.fail_after(timeout_seconds):
+                    result = await backend.call_tool(TOOL_NAME, {'venture': venture})
+                if not isinstance(result, types.CallToolResult):
+                    raise TypeError('invalid backend result')
+                if result.isError:
+                    return error_result('Backend read failed; the read allowance remains consumed.')
+                encoded = result.model_dump_json().encode('utf-8')
+                if len(encoded) > max_result_bytes:
+                    return error_result('Backend result exceeds the scoped evidence bound; narrow the task before retrying.')
+            except TimeoutError:
+                return error_result('Backend read timed out; the read allowance remains consumed.')
+            except Exception:
+                # Never echo backend exceptions, command lines, credentials or paths.
+                return error_result('Backend read failed; the read allowance remains consumed.')
+            print(json.dumps({'event': 'scoped_mcp_read', 'call': used,
+                              'result_bytes': len(encoded), 'is_error': result.isError,
+                              'result_sha256': hashlib.sha256(encoded).hexdigest()}),
+                  file=sys.stderr, flush=True)
+            return result
+
+    return server
+
+
+async def run(args):
+    # StdioServerParameters uses argv, never a shell. Backend is operator-trusted;
+    # these restrictions constrain model tool access, not arbitrary backend code.
+    params = StdioServerParameters(command=args.backend[0], args=args.backend[1:])
+    # Backend stderr may include private values. Do not reflect it to Muse/logs.
+    with open(os.devnull, 'w') as backend_errors:
+        async with stdio_client(params, errlog=backend_errors) as (read, write):
+            async with ClientSession(read, write, read_timeout_seconds=timedelta(seconds=args.timeout_seconds)) as backend:
+                with anyio.fail_after(args.timeout_seconds):
+                    await backend.initialize()
+                    available = await backend.list_tools()
+                if TOOL_NAME not in {tool.name for tool in available.tools}:
+                    raise RuntimeError('required read tool unavailable')
+                server = build_server(backend, args.venture, args.max_calls, args.timeout_seconds)
+                async with stdio_server() as (incoming, outgoing):
+                    await server.run(incoming, outgoing, server.create_initialization_options())
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--venture', required=True, help='Exact venture name/path chosen by the operator, never by the model')
+    parser.add_argument('--max-calls', type=int, choices=range(1, 11), default=1)
+    parser.add_argument('--timeout-seconds', type=int, choices=range(1, 61), default=15)
+    parser.add_argument('backend', nargs=argparse.REMAINDER, help='-- backend-command [arguments...]')
+    args = parser.parse_args(argv)
+    if args.backend[:1] == ['--']:
+        args.backend = args.backend[1:]
+    if not args.venture.strip() or len(args.venture) > 1024 or not args.backend:
+        parser.error('explicit venture and backend command are required')
+    try:
+        anyio.run(run, args)
+    except KeyboardInterrupt:
+        return 130
+    except Exception:
+        print('Scoped MCP connector failed; no backend details were disclosed.', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/fixtures/muse_mcp_backend.py
+++ b/tests/fixtures/muse_mcp_backend.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Synthetic MCP backend: no production imports, credentials, or network access."""
+
+import json
+import sys
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+
+mode = sys.argv[1]
+audit_path = Path(sys.argv[2])
+server = FastMCP("synthetic-delimit-backend")
+
+
+def record(event, **fields):
+    with audit_path.open("a", encoding="utf-8") as audit:
+        audit.write(json.dumps({"event": event, **fields}) + "\n")
+
+
+record("started")
+
+
+@server.tool()
+def forbidden_write_tool(venture: str) -> dict:
+    """A synthetic tool the adapter must never advertise or invoke."""
+    record("forbidden_called", venture=venture)
+    return {"unexpected": True}
+
+
+if mode != "missing":
+    @server.tool()
+    def delimit_ledger_context(venture: str) -> dict:
+        """Read a synthetic handoff; this function has no real ledger access."""
+        record("called", venture=venture)
+        if mode == "error":
+            raise RuntimeError("BACKEND_PRIVATE_ERROR_SENTINEL")
+        return {
+            "synthetic": True,
+            "venture": venture,
+            "open_item": "SYN-E",
+            "completed_item_to_preserve": "SYN-D",
+        }
+
+
+server.run(transport="stdio")

--- a/tests/test_muse_mcp.py
+++ b/tests/test_muse_mcp.py
@@ -1,0 +1,227 @@
+"""Independent scoped-adapter tests; all data and backends are synthetic."""
+
+import asyncio
+import contextlib
+import importlib.util
+import inspect
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters, types
+from mcp.client.stdio import stdio_client
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "scripts" / "muse_mcp.py"
+FIXTURE = ROOT / "tests" / "fixtures" / "muse_mcp_backend.py"
+spec = importlib.util.spec_from_file_location("muse_mcp_under_test", MODULE)
+muse_mcp = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = muse_mcp
+spec.loader.exec_module(muse_mcp)
+
+
+def result(text="synthetic result", **kwargs):
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=text)], **kwargs
+    )
+
+
+class Backend:
+    def __init__(self, output=None, error=None, delay=0):
+        self.output = output if output is not None else result()
+        self.error = error
+        self.delay = delay
+        self.calls = []
+        self.active = 0
+        self.peak_active = 0
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        self.active += 1
+        self.peak_active = max(self.active, self.peak_active)
+        try:
+            await asyncio.sleep(self.delay)
+            if self.error is not None:
+                raise self.error
+            return self.output
+        finally:
+            self.active -= 1
+
+
+class AdapterUnitTests(unittest.IsolatedAsyncioTestCase):
+    async def make_server(self, backend=None, **kwargs):
+        self.backend = backend or Backend()
+        server = muse_mcp.build_server(self.backend, "synthetic-demo", **kwargs)
+        return await server if inspect.isawaitable(server) else server
+
+    async def call(self, server, name="delimit_ledger_context", arguments=None):
+        request = types.CallToolRequest(params=types.CallToolRequestParams(
+            name=name, arguments={} if arguments is None else arguments
+        ))
+        return (await server.request_handlers[types.CallToolRequest](request)).root
+
+    async def test_only_scoped_read_tool_is_advertised(self):
+        server = await self.make_server()
+        listed = (await server.request_handlers[types.ListToolsRequest](
+            types.ListToolsRequest()
+        )).root.tools
+        self.assertEqual([tool.name for tool in listed], ["delimit_ledger_context"])
+        self.assertEqual(listed[0].inputSchema.get("properties", {}), {})
+        self.assertIs(listed[0].inputSchema.get("additionalProperties"), False)
+        self.assertTrue(listed[0].annotations.readOnlyHint)
+
+    async def test_fixed_venture_replaces_frontend_authority(self):
+        server = await self.make_server()
+        output = await self.call(server)
+        self.assertFalse(output.isError)
+        self.assertEqual(self.backend.calls, [
+            ("delimit_ledger_context", {"venture": "synthetic-demo"})
+        ])
+
+    async def test_caller_cannot_select_venture_or_other_arguments(self):
+        server = await self.make_server()
+        for arguments in ({"venture": "production"}, {"limit": 999}, {"x": {}}):
+            with self.subTest(arguments=arguments):
+                self.assertTrue((await self.call(server, arguments=arguments)).isError)
+        self.assertEqual(self.backend.calls, [])
+
+    async def test_unknown_write_and_namespaced_tools_are_rejected(self):
+        server = await self.make_server()
+        for name in ("forbidden_write_tool", "delimit_ledger_add", "mcp__delimit_ledger_context", ""):
+            with self.subTest(name=name):
+                self.assertTrue((await self.call(server, name=name)).isError)
+        self.assertEqual(self.backend.calls, [])
+
+    async def test_default_budget_is_one(self):
+        server = await self.make_server()
+        self.assertFalse((await self.call(server)).isError)
+        self.assertTrue((await self.call(server)).isError)
+        self.assertEqual(len(self.backend.calls), 1)
+
+    async def test_backend_exception_is_sanitized_and_consumes_budget(self):
+        server = await self.make_server(Backend(error=RuntimeError("PRIVATE_SENTINEL token=secret")))
+        output = await self.call(server)
+        self.assertTrue(output.isError)
+        self.assertNotIn("PRIVATE_SENTINEL", output.model_dump_json())
+        self.assertNotIn("token=secret", output.model_dump_json())
+        self.assertTrue((await self.call(server)).isError)
+        self.assertEqual(len(self.backend.calls), 1)
+
+    async def test_backend_error_result_does_not_leak_raw_error(self):
+        server = await self.make_server(Backend(output=result("PRIVATE_SENTINEL", isError=True)))
+        output = await self.call(server)
+        self.assertTrue(output.isError)
+        self.assertNotIn("PRIVATE_SENTINEL", output.model_dump_json())
+
+    async def test_serialized_result_bound_counts_structured_content(self):
+        server = await self.make_server(Backend(output=result(
+            "small", structuredContent={"payload": "x" * 33000}
+        )))
+        output = await self.call(server)
+        self.assertTrue(output.isError)
+        self.assertLess(len(output.model_dump_json().encode()), 32768)
+
+    async def test_result_bound_counts_utf8_bytes_not_characters(self):
+        server = await self.make_server(Backend(output=result("界" * 12000)))
+        self.assertTrue((await self.call(server)).isError)
+
+    async def test_success_preserves_structured_synthetic_evidence(self):
+        expected = result("fixture", structuredContent={"synthetic": True, "nonce": "n1"})
+        server = await self.make_server(Backend(output=expected))
+        self.assertEqual((await self.call(server)).model_dump(), expected.model_dump())
+
+    async def test_concurrent_calls_serialize_and_do_not_overspend(self):
+        server = await self.make_server(Backend(delay=0.02), max_calls=2)
+        outcomes = await asyncio.gather(*(self.call(server) for _ in range(5)))
+        self.assertEqual(sum(not item.isError for item in outcomes), 2)
+        self.assertEqual(len(self.backend.calls), 2)
+        self.assertEqual(self.backend.peak_active, 1)
+
+    async def test_timeout_is_bounded_sanitized_and_consumes_budget(self):
+        server = await self.make_server(Backend(delay=5), timeout_seconds=1)
+        output = await asyncio.wait_for(self.call(server), timeout=2)
+        self.assertTrue(output.isError)
+        self.assertTrue((await self.call(server)).isError)
+        self.assertEqual(len(self.backend.calls), 1)
+        self.assertEqual(self.backend.active, 0)
+
+    async def test_no_resource_or_prompt_passthrough_handlers(self):
+        server = await self.make_server()
+        for request in (types.ListResourcesRequest, types.ReadResourceRequest,
+                        types.ListResourceTemplatesRequest, types.ListPromptsRequest,
+                        types.GetPromptRequest):
+            self.assertNotIn(request, server.request_handlers)
+
+
+class AdapterStdioTests(unittest.IsolatedAsyncioTestCase):
+    @contextlib.asynccontextmanager
+    async def session(self, mode="ok"):
+        with tempfile.TemporaryDirectory(prefix="muse-mcp-test-") as directory:
+            audit = Path(directory) / "audit.jsonl"
+            params = StdioServerParameters(command=sys.executable, args=[
+                str(MODULE), "--venture", "synthetic-demo", "--timeout-seconds", "2",
+                "--max-calls", "1", "--", sys.executable, str(FIXTURE), mode, str(audit)
+            ])
+            with open(Path(directory) / "stderr.log", "w", encoding="utf-8") as errlog:
+                async with stdio_client(params, errlog=errlog) as (read, write):
+                    async with ClientSession(read, write) as client:
+                        await client.initialize()
+                        yield client, audit
+
+    async def test_real_stdio_handshake_list_and_fixed_scope_call(self):
+        async with self.session() as (client, audit):
+            listed = await client.list_tools()
+            self.assertEqual([tool.name for tool in listed.tools], ["delimit_ledger_context"])
+            denied = await client.call_tool("forbidden_write_tool", {"venture": "root"})
+            self.assertTrue(denied.isError)
+            denied = await client.call_tool("delimit_ledger_context", {"venture": "root"})
+            self.assertTrue(denied.isError)
+            actual = await client.call_tool("delimit_ledger_context", {})
+            self.assertFalse(actual.isError)
+            evidence = actual.structuredContent or json.loads(actual.content[0].text)
+            self.assertEqual(evidence["venture"], "synthetic-demo")
+            self.assertTrue(evidence["synthetic"])
+            self.assertEqual(evidence["open_item"], "SYN-E")
+            self.assertTrue((await client.call_tool("delimit_ledger_context", {})).isError)
+            events = [json.loads(line) for line in audit.read_text().splitlines()]
+            self.assertEqual([e for e in events if e["event"] == "called"], [
+                {"event": "called", "venture": "synthetic-demo"}
+            ])
+            self.assertFalse(any(e["event"] == "forbidden_called" for e in events))
+
+    async def test_real_stdio_backend_error_is_sanitized(self):
+        async with self.session("error") as (client, _):
+            output = await client.call_tool("delimit_ledger_context", {})
+            self.assertTrue(output.isError)
+            self.assertNotIn("BACKEND_PRIVATE_ERROR_SENTINEL", output.model_dump_json())
+
+
+class AdapterCLITests(unittest.TestCase):
+    def test_cli_rejects_invalid_caps_before_backend_start(self):
+        for flag, value in (("--max-calls", "0"), ("--max-calls", "11"),
+                            ("--timeout-seconds", "0"), ("--timeout-seconds", "61")):
+            with self.subTest(flag=flag, value=value):
+                process = subprocess.run([sys.executable, str(MODULE), "--venture", "synthetic-demo",
+                    flag, value, "--", "must-not-execute-nonexistent-backend"],
+                    capture_output=True, text=True, timeout=5)
+                self.assertNotEqual(process.returncode, 0)
+                self.assertNotIn("FileNotFoundError", process.stderr)
+
+    def test_missing_backend_tool_fails_startup_without_invocation(self):
+        with tempfile.TemporaryDirectory(prefix="muse-mcp-missing-") as directory:
+            audit = Path(directory) / "audit.jsonl"
+            process = subprocess.run([sys.executable, str(MODULE), "--venture", "synthetic-demo",
+                "--timeout-seconds", "2", "--", sys.executable, str(FIXTURE), "missing", str(audit)],
+                input="", capture_output=True, text=True, timeout=10)
+            self.assertNotEqual(process.returncode, 0)
+            self.assertNotIn("Traceback", process.stderr)
+            events = [json.loads(line) for line in audit.read_text().splitlines()]
+            self.assertEqual(events, [{"event": "started"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reuse the Python MCP SDK to expose one operator-scoped ledger-context read over stdio.
- Reject scope overrides and all other tools; bound calls, time and output; sanitize backend failures.
- Add synthetic protocol tests and CI coverage, plus conditional Muse configuration documentation.

## Verification
- 17 new unit and real stdio integration tests passed.
- All 429 existing Node tests passed, including pre-push checks.
- Bundle classification and npm tarball parity passed.
- Independent multi-model review approved implementation, docs and CI.
- Isolated offline Muse Code 1.1.1 registration verified handshake, one tool, no resources/prompts and clean shutdown. No private backend or new Muse inference used.

## Limits
This does not bypass native Muse tool approvals or establish unattended operation. The read allowance is per process, not a durable permit. The operator must separately authorize any private-data backend and its selected model route. No production routing, global configuration or billing changes.